### PR TITLE
Add competitor domain model and result tables to event module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ API keys are bcrypt hashes (cost 12). First account via `FIRST_OWNER` + `FIRST_H
 | `application-{local,dev,prod}.yaml` | profile-specific overrides                               |
 | `application-secrets.yaml`          | credentials (gitignored, from `template-secrets.yaml`)   |
 | `application-test.yaml`             | H2 in-memory DB for tests                                |
-| `sonar-project.properties`          | SonarQube Cloud project key, host, CPD exclusions        |
-| `pom.xml`                           | `<sonar.organization>endurancecode</sonar.organization>` |
+| `sonar-project.properties`          | SonarQube Cloud project key, host, source encoding       |
+| `pom.xml`                           | `<sonar.organization>`, CPD and analysis exclusions       |
 
 Profiles: `local` (localhost PG), `dev`/`prod` (env-var PG), `test` (H2). Activate via `-Dspring.profiles.active=local` or `-Dspring-boot.run.profiles=local`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Entrypoint: `com.endurancetrio.app.EnduranceTrioApplication` (port 8080, Thymele
 - Entity base classes: `BaseEntity<T>` (id, equals, hashCode), `AuditableEntity` (version, createdAt, updatedAt)
 - Flyway: `V{major}.{minor}.{patch}.{order}__description.sql` in `endurancetrio-data/src/main/resources/db/migration/{ddl,dml}/{h2,postgres}/`
 - DB naming: snake_case, plural tables, constraint prefixes (`pk_`, `fk_`, `uk_`, `chk_`, `idx_`, `seq_`)
+- Historical reference entities: `AgeGroup` and `ParaClass` under `competitor.model.entity` exist solely to document their database table schemas for historical data storage. They are NOT used in application code. The active counterparts are the enums in `competitor.model.enumerator`, stored as VARCHAR columns in result tables.
 - Config files (`*.yaml`, `*.properties`): keys ordered alphabetically (root-level and nested). See [`docs/development.md`](docs/development.md#configuration-file-key-ordering)
 
 ## Tracker integration (dual-repo)

--- a/docker/deployment/scripts/init-db.sh
+++ b/docker/deployment/scripts/init-db.sh
@@ -59,24 +59,3 @@ psql -v ON_ERROR_STOP=1 \
     WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = :'prd_user')\gexec
     GRANT ALL PRIVILEGES ON DATABASE prd_endurancetrio_community TO :"prd_user";
 EOSQL
-
-# Grant schema-level permissions (required for Flyway and JPA to create/alter objects)
-for db in stg_endurancetrio_community prd_endurancetrio_community; do
-    case "$db" in
-        stg_endurancetrio_community)
-            db_user="${STG_DB_USERNAME}"
-            ;;
-        prd_endurancetrio_community)
-            db_user="${PRD_DB_USERNAME}"
-            ;;
-    esac
-    psql -v ON_ERROR_STOP=1 \
-         -v db_user="$db_user" \
-         --username "$POSTGRES_USER" --dbname "$db" <<-'EOSQL'
-        GRANT ALL ON SCHEMA public TO :"db_user";
-        GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :"db_user";
-        GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :"db_user";
-        ALTER DEFAULT PRIVILEGES FOR ROLE :"db_user" IN SCHEMA public GRANT ALL ON TABLES TO :"db_user";
-        ALTER DEFAULT PRIVILEGES FOR ROLE :"db_user" IN SCHEMA public GRANT ALL ON SEQUENCES TO :"db_user";
-EOSQL
-done

--- a/docs/development.md
+++ b/docs/development.md
@@ -690,6 +690,351 @@ public interface UserRepository extends JpaRepository<User, Long> {
 }
 ```
 
+### Entity Layer
+
+This section documents how JPA entities should be created and managed in the `endurancetrio-data`
+module.
+
+#### Package Structure
+
+Each domain group follows a consistent package layout under
+`com.endurancetrio.data.{domain}.model`:
+
+```
+{domain}/
+  model/
+    converter/          → JPA AttributeConverter implementations
+    entity/             → JPA entity classes
+    enumerator/         → Code-backed enums stored as VARCHAR columns
+```
+
+#### Base Classes
+
+Two base class options are available, chosen based on the primary key strategy:
+
+**1. `BaseEntity<Long>`** — for entities with a surrogate, sequence-generated `id`:
+
+- **`id`** — auto-generated primary key via `GenerationType.SEQUENCE`
+- **`version`** — optimistic locking field (`@Version`)
+- **`createdAt` / `updatedAt`** — auditing timestamps via `@CreatedDate` / `@LastModifiedDate`
+- **`equals()` / `hashCode()`** — ID-based equality (same class + same non-null ID)
+
+```java
+public class MyEntity extends BaseEntity<Long> { ... }
+```
+
+Only entities that need a non-`Long` ID type should extend `BaseEntity` with a different type
+parameter; currently all entities use `Long`.
+
+**2. `AuditableEntity`** — for entities with a natural (business) primary key that is assigned
+rather than generated:
+
+- **`version`** — optimistic locking field (`@Version`)
+- **`createdAt` / `updatedAt`** — auditing timestamps via `@CreatedDate` / `@LastModifiedDate`
+- **No auto-generated ID** — the entity defines its own `@Id` on a natural key field
+
+```java
+public class MyEntity extends AuditableEntity { ... }
+```
+
+#### Entity Declaration
+
+```java
+
+@Entity(name = "MyEntity")
+@Table(name = "my_entity")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator",
+    sequenceName = "seq_my_entity_id",
+    allocationSize = 1
+)
+public class MyEntity extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+```
+
+- `@Entity(name = "...")` must use the simple PascalCase class name.
+- `@Table(name = "...")` must use snake_case, plural table names matching the database schema.
+- `@SequenceGenerator` must use the shared generator name `seq_endurancetrio_generator` and a
+  sequence name following the pattern `seq_{table}_id`.
+- Every entity must declare `@Serial private static final long serialVersionUID = 1L`.
+
+#### Natural Key Entities
+
+Entities with a natural (business) primary key extend `AuditableEntity` directly rather than
+`BaseEntity<Long>`. This pattern is used when the primary key is assigned in application code and
+has business meaning (e.g., `TrackerAccount` keyed by `owner`).
+
+```java
+@Entity
+@Table(name = "my_natural_entity")
+public class MyNaturalEntity extends AuditableEntity {
+
+  @Id
+  @Column(name = "natural_key", nullable = false, unique = true, length = 50)
+  private String naturalKey;
+```
+
+- `@Entity` does **not** require a `name` attribute; the class name is used by default.
+- No `@SequenceGenerator` is declared — the identifier is assigned, not generated.
+- The `@Id` field is the natural key and must be annotated with `@Column(unique = true)`.
+- `equals()` and `hashCode()` are based on the natural key field(s), not delegated to `super`.
+- Use `@Column(length = ...)` to constrain the natural key column size.
+
+#### Javadoc Convention
+
+Every entity must have a class-level Javadoc block describing what the entity represents, followed
+by a `<ul>` documenting each field with a link to its getter:
+
+```java
+/**
+ * The {@link MyEntity} entity represents ...
+ * <p>
+ * The {@link MyEntity}'s fields are defined as follows:
+ * <ul>
+ *   <li>
+ *     {@link #getId() id} : the unique identifier ...
+ *   </li>
+ *   <li>
+ *     {@link #getFieldName() fieldName} : the description ...
+ *   </li>
+ * </ul>
+ */
+```
+
+#### Constructor
+
+Always provide a public no-argument constructor that calls `super()`. Initialize collection fields
+to `new HashSet<>()` in the constructor:
+
+```java
+public MyEntity() {
+  super();
+  this.children = new HashSet<>();
+}
+```
+
+#### Field & Column Naming
+
+- Fields follow camelCase in Java.
+- `@Column(name = "...")` uses snake_case matching the database column.
+- Nullable columns omit `nullable`; required columns use `nullable = false`.
+- Boolean fields use the `is` prefix for the field name (e.g., `isActive`) and `get`/`set` prefix
+  for
+  accessors (e.g., `getActive()`, `setActive()`).
+- Enum fields are annotated with `@Convert(converter = XxxConverter.class)` and stored as VARCHAR
+  codes, never as ORDINAL.
+- Validation annotations (`@Pattern`, `@AssertTrue`) are placed on the field directly.
+
+```java
+
+@Column(name = "full_name", nullable = false)
+private String fullName;
+
+@Column(name = "is_active", nullable = false)
+private Boolean isActive;
+
+@Column(name = "race_type", nullable = false)
+@Convert(converter = RaceTypeConverter.class)
+private RaceType raceType;
+```
+
+#### Associations
+
+All associations use `FetchType.LAZY`. Use `Set<>` (not `List`) for collection fields:
+
+| Annotation    | Cascade                  | Example                                                         |
+|---------------|--------------------------|-----------------------------------------------------------------|
+| `@ManyToOne`  | None                     | `@ManyToOne(fetch = FetchType.LAZY)`                            |
+| `@OneToOne`   | `ALL` + `orphanRemoval`  | `@OneToOne(fetch = LAZY, cascade = ALL, orphanRemoval = true)`  |
+| `@OneToMany`  | `ALL` + `orphanRemoval`  | `@OneToMany(fetch = LAZY, cascade = ALL, orphanRemoval = true)` |
+| `@ManyToMany` | `PERSIST, MERGE` or none | `@ManyToMany(fetch = FetchType.LAZY)`                           |
+
+- `@OneToMany` with `@JoinColumn` (foreign key on child table) is preferred over `mappedBy` when the
+  child has no inverse reference.
+- `@ManyToMany` always uses a `@JoinTable` with explicit join column names.
+
+#### Bidirectional Helper Methods
+
+When both sides of a relationship exist, provide `addXxx` / `removeXxx` helper methods that maintain
+consistency on both sides:
+
+```java
+public void addChild(Child child) {
+  if (child != null && this.children.add(child)) {
+    child.setParent(this);
+  }
+}
+
+public void removeChild(Child child) {
+  if (child != null && this.children.remove(child)) {
+    child.setParent(null);
+  }
+}
+```
+
+#### Method Ordering
+
+Methods in an entity class follow this order:
+
+1. Javadoc + class declaration
+2. `@Serial` / `serialVersionUID`
+3. Fields (simple columns first, associations last)
+4. Constructor(s)
+5. `@AssertTrue` validation methods
+6. Bidirectional helper methods (`addXxx` / `removeXxx`)
+7. Getters and setters (alphabetically by field name)
+8. `equals(Object)` → delegates to `super.equals(o)` (or natural key check for `AuditableEntity` entities)
+9. `hashCode()` → delegates to `super.hashCode()` (or natural key hash for `AuditableEntity` entities)
+10. `toString()` → uses `StringJoiner`
+
+#### equals(), hashCode() and toString()
+
+- **Surrogate key entities** (extending `BaseEntity`): `equals()` and `hashCode()` must delegate to
+  `super` (the `BaseEntity` ID-based contract):
+
+```java
+@Override
+public boolean equals(Object o) {
+  return super.equals(o);
+}
+
+@Override
+public int hashCode() {
+  return super.hashCode();
+}
+```
+
+- **Natural key entities** (extending `AuditableEntity` directly): `equals()` and `hashCode()` must
+  be implemented based on the natural key field(s):
+
+```java
+@Override
+public boolean equals(Object o) {
+  if (this == o) {
+    return true;
+  }
+
+  if (!(o instanceof NaturalKeyEntity that)) {
+    return false;
+  }
+
+  Class<?> thisClass = org.hibernate.Hibernate.getClass(this);
+  Class<?> thatClass = org.hibernate.Hibernate.getClass(that);
+
+  if (thisClass != thatClass) {
+    return false;
+  }
+
+  return naturalKey != null && naturalKey.equals(that.getNaturalKey());
+}
+
+@Override
+public int hashCode() {
+  return Objects.hash(naturalKey);
+}
+```
+
+- `toString()` must use `StringJoiner` with the pattern
+  `EntityName.class.getSimpleName() + "[", "]"`. Include all scalar fields and, for associations,
+  only the referenced entity's ID (using
+  `Optional.ofNullable(...).map(X::getId).orElse(null)`):
+
+```java
+
+@Override
+public String toString() {
+  return new StringJoiner(", ", MyEntity.class.getSimpleName() + "[", "]")
+      .add("id=" + this.getId())
+      .add("name='" + name + "'")
+      .add("parentId=" + Optional.ofNullable(parent).map(Parent::getId).orElse(null))
+      .toString();
+}
+```
+
+#### Enums
+
+All persisted enums must use a code-based pattern with a dedicated JPA `AttributeConverter`:
+
+```java
+public enum MyEnum {
+  VALUE_A("VALUE_A"),
+  VALUE_B("VALUE_B");
+
+  private final String code;
+
+  MyEnum(String code) {
+    this.code = code;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String toString() {
+    return code;
+  }
+}
+```
+
+**Converter:**
+
+```java
+
+@Converter
+public class MyEnumConverter implements AttributeConverter<MyEnum, String> {
+
+  @Override
+  public String convertToDatabaseColumn(MyEnum value) {
+    return Optional.ofNullable(value).map(MyEnum::getCode).orElse(null);
+  }
+
+  @Override
+  public MyEnum convertToEntityAttribute(String code) {
+    return Stream.of(MyEnum.values())
+        .filter(e -> e.getCode().equals(code))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "The value '" + code + "' returned from the database is not a valid MyEnum code"));
+  }
+}
+```
+
+- Enums live in `{domain}.model.enumerator`.
+- Converters live in `{domain}.model.converter`.
+- Never use `EnumType.ORDINAL` or `EnumType.STRING` — always go through a converter.
+
+#### Inheritance
+
+Use `@Inheritance(strategy = InheritanceType.JOINED)` when entities share a common base table:
+
+```java
+
+@Entity(name = "Race")
+@Table(name = "race")
+@Inheritance(strategy = InheritanceType.JOINED)
+public class Race extends BaseEntity<Long> { ...
+}
+```
+
+#### Historical Reference Entities
+
+Entities that exist solely to map database tables for historical data (not used in application
+logic) must be documented as such in their Javadoc:
+
+```java
+/**
+ * Historical reference entity that documents the {@code old_table} table schema.
+ * <p>
+ * This entity exists solely to map the database table for historical data storage.
+ * It is NOT used in application code.
+ * <p>
+ * Do NOT import or reference this entity in business logic.
+ */
+```
+
 ### Configuration File Key Ordering
 
 All `application-*.yaml` and `*.properties` files must follow a consistent key ordering convention

--- a/endurancetrio-app/src/main/resources/application-local.yaml
+++ b/endurancetrio-app/src/main/resources/application-local.yaml
@@ -30,7 +30,7 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/endurancetrio_community
+    url: jdbc:postgresql://localhost:5432/dev_endurancetrio_community
 
   devtools:
     livereload:

--- a/endurancetrio-app/src/main/resources/application.yaml
+++ b/endurancetrio-app/src/main/resources/application.yaml
@@ -102,7 +102,7 @@ spring:
     out-of-order: true
     placeholders:
       timezone: UTC
-    schemas: endurancetrio_community
+    schemas: endurancetrio_hub
     table: flyway_schema_history
     validate-on-migrate: true
 
@@ -114,7 +114,7 @@ spring:
     open-in-view: false
     properties:
       hibernate:
-        default_schema: endurancetrio_community
+        default_schema: endurancetrio_hub
         format_sql: true
         jdbc:
           time_zone: UTC

--- a/endurancetrio-app/src/test/resources/application-test.yaml
+++ b/endurancetrio-app/src/test/resources/application-test.yaml
@@ -26,7 +26,7 @@ logging:
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:endurancetrio_community;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    url: jdbc:h2:mem:dev_endurancetrio_community;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
     username: user
     password: password
 
@@ -41,7 +41,7 @@ spring:
     out-of-order: true
     placeholders:
       timezone: UTC
-    schemas: endurancetrio_community
+    schemas: endurancetrio_hub
     table: flyway_schema_history
     validate-on-migrate: true
 
@@ -53,7 +53,7 @@ spring:
     open-in-view: false
     properties:
       hibernate:
-        default_schema: endurancetrio_community
+        default_schema: endurancetrio_hub
         format_sql: true
         jdbc:
           time_zone: UTC

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/AgeGroupConverter.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/AgeGroupConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import com.endurancetrio.data.competitor.model.enumerator.AgeGroup;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The {@link AgeGroupConverter} class is responsible for converting the {@link AgeGroup} enum to
+ * its corresponding database column representation and vice versa.
+ * <p>
+ * This converter is used to persist the {@link AgeGroup} enum as a string in the database. It
+ * converts the enum to its code when storing it in the database and converts the code back to the
+ * enum when retrieving it from the database.
+ */
+@Converter
+public class AgeGroupConverter implements AttributeConverter<AgeGroup, String> {
+
+  @Override
+  public String convertToDatabaseColumn(AgeGroup ageGroup) {
+    return Optional.ofNullable(ageGroup).map(AgeGroup::getCode).orElse(null);
+  }
+
+  @Override
+  public AgeGroup convertToEntityAttribute(String code) {
+    return Stream.of(AgeGroup.values())
+        .filter(ageGroup -> ageGroup.getCode().equals(code.toUpperCase()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            String.format("The value '%s' returned from the database is not valid", code)));
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/AthleteGenderConverter.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/AthleteGenderConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import com.endurancetrio.data.competitor.model.enumerator.AthleteGender;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The {@link AthleteGenderConverter} class is responsible for converting the {@link AthleteGender}
+ * enum to its corresponding database column representation and vice versa.
+ * <p>
+ * This converter is used to persist the {@link AthleteGender} enum as a string in the database. It
+ * converts the enum to its code when storing it in the database and converts the code back to the
+ * enum when retrieving it from the database.
+ */
+@Converter
+public class AthleteGenderConverter implements AttributeConverter<AthleteGender, String> {
+
+  @Override
+  public String convertToDatabaseColumn(AthleteGender athleteGender) {
+    return Optional.ofNullable(athleteGender).map(AthleteGender::getCode).orElse(null);
+  }
+
+  @Override
+  public AthleteGender convertToEntityAttribute(String code) {
+    return Stream.of(AthleteGender.values())
+        .filter(gender -> gender.getCode().equals(code))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "The value '" + code + "' returned from the database is not a valid AthleteGender"));
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/CountryConverter.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/CountryConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import com.endurancetrio.data.competitor.model.enumerator.Country;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The {@link CountryConverter} class is responsible for converting the {@link Country} enum to its
+ * corresponding database column representation and vice versa.
+ * <p>
+ * This converter is used to persist the {@link Country} enum as a string in the database. It
+ * converts the enum to its NOC code when storing it in the database and converts the code back to
+ * the enum when retrieving it from the database.
+ */
+@Converter
+public class CountryConverter implements AttributeConverter<Country, String> {
+
+  @Override
+  public String convertToDatabaseColumn(Country country) {
+    return Optional.ofNullable(country).map(Country::getCode).orElse(null);
+  }
+
+  @Override
+  public Country convertToEntityAttribute(String code) {
+    return Stream.of(Country.values())
+        .filter(country -> country.getCode().equals(code))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "The value '" + code + "' returned from the database is not a valid Country code"));
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/ParaClassConverter.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/converter/ParaClassConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import com.endurancetrio.data.competitor.model.enumerator.ParaClass;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The {@link ParaClassConverter} class is responsible for converting the {@link ParaClass} enum to
+ * its corresponding database column representation and vice versa.
+ * <p>
+ * This converter is used to persist the {@link ParaClass} enum as a string in the database. It
+ * converts the enum to its code when storing it in the database and converts the code back to the
+ * enum when retrieving it from the database.
+ */
+@Converter
+public class ParaClassConverter implements AttributeConverter<ParaClass, String> {
+
+  @Override
+  public String convertToDatabaseColumn(ParaClass paraClass) {
+    return Optional.ofNullable(paraClass).map(ParaClass::getCode).orElse(null);
+  }
+
+  @Override
+  public ParaClass convertToEntityAttribute(String code) {
+    return Stream.of(ParaClass.values())
+        .filter(paraClass -> paraClass.getCode().equals(code.toUpperCase()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            String.format("The value '%s' returned from the database is not valid", code)));
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/AgeGroup.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/AgeGroup.java
@@ -18,7 +18,7 @@
  * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
  */
 
-package com.endurancetrio.data.event.model.entity;
+package com.endurancetrio.data.competitor.model.entity;
 
 import com.endurancetrio.data.common.model.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -29,56 +29,60 @@ import java.io.Serial;
 import java.util.StringJoiner;
 
 /**
- * The {@link AgeGroup} entity represents the participants age group category allowed to
- * enter a {@link Race}.
+ * Historical reference entity that documents the {@code age_group} table schema.
  * <p>
- * The {@link AgeGroup}'s fields are defined as follows:
- * <ul>
- *   <li>
- *     {@link #getId() id} : the unique identifier of the {@link AgeGroup} that
- *     is automatically generated and is the primary key.
- *   </li>
- *   <li>{@link #getTitle() title} : the full title of the {@link AgeGroup age group}.</li>
- *   <li>
- *     {@link #getShortTitle() shortTitle} : the abbreviated title of the {@link AgeGroup age group}.
- *   </li>
- * </ul>
+ * This entity exists solely to map the database table for historical data storage. It is NOT used
+ * in application code. The active representation of age group data is the
+ * {@link com.endurancetrio.data.competitor.model.enumerator.AgeGroup} enum, which is stored as a
+ * VARCHAR column in result tables.
+ * <p>
+ * Do NOT import or reference this entity in business logic.
  */
 @Entity(name = "AgeGroup")
 @Table(name = "age_group")
-@SequenceGenerator(name = "seq_endurancetrio_generator", sequenceName = "seq_age_group_id", allocationSize = 1)
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator", sequenceName = "seq_age_group_id", allocationSize = 1
+)
 public class AgeGroup extends BaseEntity<Long> {
 
   @Serial
   private static final long serialVersionUID = 1L;
 
-  @Column(name = "title", nullable = false)
-  private String title;
+  @Column(name = "code", nullable = false)
+  private String code;
 
-  @Column(name = "short_title", nullable = false)
-  private String shortTitle;
+  @Column(name = "denomination_en", nullable = false)
+  private String denominationEN;
 
-  /**
-   * Default constructor for the {@link AgeGroup} entity.
-   */
+  @Column(name = "denomination_pt", nullable = false)
+  private String denominationPT;
+
   public AgeGroup() {
     super();
   }
 
-  public String getTitle() {
-    return title;
+  public String getCode() {
+    return code;
   }
 
-  public void setTitle(String title) {
-    this.title = title;
+  public void setCode(String code) {
+    this.code = code;
   }
 
-  public String getShortTitle() {
-    return shortTitle;
+  public String getDenominationEN() {
+    return denominationEN;
   }
 
-  public void setShortTitle(String shortTitle) {
-    this.shortTitle = shortTitle;
+  public void setDenominationEN(String denominationEN) {
+    this.denominationEN = denominationEN;
+  }
+
+  public String getDenominationPT() {
+    return denominationPT;
+  }
+
+  public void setDenominationPT(String denominationPT) {
+    this.denominationPT = denominationPT;
   }
 
   @Override
@@ -95,8 +99,9 @@ public class AgeGroup extends BaseEntity<Long> {
   public String toString() {
     return new StringJoiner(", ", AgeGroup.class.getSimpleName() + "[", "]")
         .add("id=" + this.getId())
-        .add("title='" + title + "'")
-        .add("shortTitle='" + shortTitle + "'")
+        .add("code='" + code + "'")
+        .add("denominationEN='" + denominationEN + "'")
+        .add("denominationPT='" + denominationPT + "'")
         .toString();
   }
 }

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/Athlete.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/Athlete.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.entity;
+
+import com.endurancetrio.data.common.model.entity.BaseEntity;
+import com.endurancetrio.data.competitor.model.converter.AthleteGenderConverter;
+import com.endurancetrio.data.competitor.model.converter.CountryConverter;
+import com.endurancetrio.data.competitor.model.enumerator.AthleteGender;
+import com.endurancetrio.data.competitor.model.enumerator.Country;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.io.Serial;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+/**
+ * The {@link Athlete} entity represents an individual competitor in the system.
+ * <p>
+ * The {@link Athlete}'s fields are defined as follows:
+ * <ul>
+ *   <li>
+ *     {@link #getId() id} : the unique identifier of the {@link Athlete} that
+ *     is automatically generated and is the primary key.
+ *   </li>
+ *   <li>
+ *     {@link #getFullName() fullName} : the athlete's full name.
+ *   </li>
+ *   <li>
+ *     {@link #getKnownName() knownName} : the athlete's known or preferred name.
+ *   </li>
+ *   <li>
+ *     {@link #getGender() gender} : the {@link AthleteGender} of the athlete.
+ *   </li>
+ *   <li>
+ *     {@link #getCountry() country} : the athlete's {@link Country} of representation.
+ *   </li>
+ *   <li>
+ *     {@link #getYearOfBirth() yearOfBirth} : the athlete's year of birth.
+ *   </li>
+ * </ul>
+ */
+@Entity(name = "Athlete")
+@Table(name = "athlete")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator", sequenceName = "seq_athlete_id", allocationSize = 1
+)
+public class Athlete extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Column(name = "full_name", nullable = false)
+  private String fullName;
+
+  @Column(name = "known_name")
+  private String knownName;
+
+  @Column(name = "gender")
+  @Convert(converter = AthleteGenderConverter.class)
+  private AthleteGender gender;
+
+  @Column(name = "country")
+  @Convert(converter = CountryConverter.class)
+  private Country country;
+
+  @Column(name = "year_of_birth")
+  private Integer yearOfBirth;
+
+  public Athlete() {
+    super();
+  }
+
+  public String getFullName() {
+    return fullName;
+  }
+
+  public void setFullName(String fullName) {
+    this.fullName = fullName;
+  }
+
+  public String getKnownName() {
+    return knownName;
+  }
+
+  public void setKnownName(String knownName) {
+    this.knownName = knownName;
+  }
+
+  public AthleteGender getGender() {
+    return gender;
+  }
+
+  public void setGender(AthleteGender gender) {
+    this.gender = gender;
+  }
+
+  public Country getCountry() {
+    return country;
+  }
+
+  public void setCountry(Country country) {
+    this.country = country;
+  }
+
+  public Integer getYearOfBirth() {
+    return yearOfBirth;
+  }
+
+  public void setYearOfBirth(Integer yearOfBirth) {
+    this.yearOfBirth = yearOfBirth;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", Athlete.class.getSimpleName() + "[", "]")
+        .add("id=" + this.getId())
+        .add("name='" + fullName + "'")
+        .add("knownName='" + knownName + "'")
+        .add("gender=" + Optional.ofNullable(gender).map(AthleteGender::getCode).orElse(null))
+        .add("country=" + Optional.ofNullable(country).map(Country::getCode).orElse(null))
+        .add("yearOfBirth=" + yearOfBirth)
+        .toString();
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/ParaClass.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/ParaClass.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.entity;
+
+import com.endurancetrio.data.common.model.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.io.Serial;
+import java.util.StringJoiner;
+
+/**
+ * Historical reference entity that documents the {@code para_class} table schema.
+ * <p>
+ * This entity exists solely to map the database table for historical data storage. It is NOT used
+ * in application code. The active representation of para class data is the
+ * {@link com.endurancetrio.data.competitor.model.enumerator.ParaClass} enum, which is stored as a
+ * VARCHAR column in result tables.
+ * <p>
+ * Do NOT import or reference this entity in business logic.
+ */
+@Entity(name = "ParaClass")
+@Table(name = "para_class")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator", sequenceName = "seq_para_class_id", allocationSize = 1
+)
+public class ParaClass extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Column(name = "code", nullable = false)
+  private String code;
+
+  @Column(name = "denomination_en", nullable = false)
+  private String denominationEN;
+
+  @Column(name = "denomination_pt", nullable = false)
+  private String denominationPT;
+
+  public ParaClass() {
+    super();
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public String getDenominationEN() {
+    return denominationEN;
+  }
+
+  public void setDenominationEN(String denominationEN) {
+    this.denominationEN = denominationEN;
+  }
+
+  public String getDenominationPT() {
+    return denominationPT;
+  }
+
+  public void setDenominationPT(String denominationPT) {
+    this.denominationPT = denominationPT;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", ParaClass.class.getSimpleName() + "[", "]")
+        .add("id=" + this.getId())
+        .add("code='" + code + "'")
+        .add("denominationEN='" + denominationEN + "'")
+        .add("denominationPT='" + denominationPT + "'")
+        .toString();
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/Team.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/entity/Team.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.entity;
+
+import com.endurancetrio.data.common.model.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.io.Serial;
+import java.util.StringJoiner;
+
+/**
+ * The {@link Team} entity represents a collective competitor (club or team).
+ * <p>
+ * The {@link Team}'s fields are defined as follows:
+ * <ul>
+ *   <li>
+ *     {@link #getId() id} : the unique identifier of the {@link Team} that
+ *     is automatically generated and is the primary key.
+ *   </li>
+   *   <li>{@link #getFullName() name} : the canonical name of the {@link Team}.</li>
+   *   <li>
+   *     {@link #getShortName() shortName} : the abbreviated or short name for the {@link Team}
+   *     (e.g., initials like "SC" for a sports club).
+   *   </li>
+   *   <li>{@link #getCity() city} : the city where the {@link Team} is based.</li>
+ *   <li>{@link #getCounty() county} : the county where the {@link Team} is based.</li>
+ *   <li>{@link #getDistrict() district} : the district where the {@link Team} is based.</li>
+ * </ul>
+ */
+@Entity(name = "Team")
+@Table(name = "team")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator", sequenceName = "seq_team_id", allocationSize = 1
+)
+public class Team extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @Column(name = "full_name", nullable = false)
+  private String fullName;
+
+  @Column(name = "short_name")
+  private String shortName;
+
+  @Column(name = "city")
+  private String city;
+
+  @Column(name = "county")
+  private String county;
+
+  @Column(name = "district")
+  private String district;
+
+  public Team() {
+    super();
+  }
+
+  public String getFullName() {
+    return fullName;
+  }
+
+  public void setFullName(String fullName) {
+    this.fullName = fullName;
+  }
+
+  public String getShortName() {
+    return shortName;
+  }
+
+  public void setShortName(String shortName) {
+    this.shortName = shortName;
+  }
+
+  public String getCity() {
+    return city;
+  }
+
+  public void setCity(String city) {
+    this.city = city;
+  }
+
+  public String getCounty() {
+    return county;
+  }
+
+  public void setCounty(String county) {
+    this.county = county;
+  }
+
+  public String getDistrict() {
+    return district;
+  }
+
+  public void setDistrict(String district) {
+    this.district = district;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", Team.class.getSimpleName() + "[", "]")
+        .add("id=" + this.getId())
+        .add("name='" + fullName + "'")
+        .add("shortName='" + shortName + "'")
+        .add("city='" + city + "'")
+        .add("county='" + county + "'")
+        .add("district='" + district + "'")
+        .toString();
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/AgeGroup.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/AgeGroup.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.enumerator;
+
+/**
+ * The {@link AgeGroup} enum represents the age group category of a competitor in a race.
+ * <p>
+ * Each constant includes the persistence code, the English name, and the European Portuguese name.
+ * The code is used for persistence and API interchange, while the full names are available for
+ * display purposes in their respective languages.
+ */
+public enum AgeGroup {
+  OPEN("OPEN", "Open", "Geral"),
+  CAT_A("A", "Category A", "Escalão A"),
+  CAT_B("B", "Category B", "Escalão B"),
+  CAT_C("C", "Category C", "Escalão C"),
+  CAT_D("D", "Category D", "Escalão D"),
+  CAT_E("E", "Category E", "Escalão E"),
+  CAT_F("F", "Category F", "Escalão F"),
+  CAT_F1("F1", "Category F1", "Escalão F1"),
+  CAT_F2("F2", "Category F2", "Escalão F2"),
+  CAT_F3("F3", "Category F3", "Escalão F3"),
+  CAT_F4("F4", "Category F4", "Escalão F4"),
+  CAT_M1("M1", "Category M1", "Escalão M1"),
+  CAT_M2("M2", "Category M2", "Escalão M2"),
+  CAT_M3("M3", "Category M3", "Escalão M3"),
+  CAT_M4("M4", "Category M4", "Escalão M4"),
+  MINI("MINI", "Mini", "Mini"),
+  PRI("PRI", "Novice", "Principiante"),
+  BEN("BEN", "Benjamin", "Benjamin"),
+  INF("INF", "Infant", "Infantil"),
+  INI("INI", "Initiate", "Iniciado"),
+  JUV("JUV", "Juvenile", "Juvenil"),
+  A1("A1", "Group 1", "Agrupamento 1"),
+  A2("A2", "Group 2", "Agrupamento 2"),
+  CAD("CAD", "Cadet", "Cadete"),
+  JUN("JUN", "Junior", "Junior"),
+  YOUTH("YOUTH", "Youth", "Youth"),
+  U23("U23", "Under 23", "Sub-23"),
+  ELITE("ELITE", "Elite", "Elite"),
+  SEN("SEN", "Senior", "Sénior"),
+  VET("VET", "Veteran", "Veterano"),
+  VET_V1("V1", "Veteran I", "Veterano I"),
+  VET_V2("V2", "Veteran II", "Veterano II"),
+  VET_V3("V3", "Veteran III", "Veterano III"),
+  VET_V4("V4", "Veteran IV", "Veterano IV"),
+  VET_V5("V5", "Veteran V", "Veterano V"),
+  AG_16_17("16-17", "Age Group 16-17", "Grupo de Idade 16-17"),
+  AG_18_19("18-19", "Age Group 18-19", "Grupo de Idade 18-19"),
+  AG_20_24("20-24", "Age Group 20-24", "Grupo de Idade 20-24"),
+  AG_25_29("25-29", "Age Group 25-29", "Grupo de Idade 25-29"),
+  AG_30_34("30-34", "Age Group 30-34", "Grupo de Idade 30-34"),
+  AG_35_39("35-39", "Age Group 35-39", "Grupo de Idade 35-39"),
+  AG_40_44("40-44", "Age Group 40-44", "Grupo de Idade 40-44"),
+  AG_45_49("45-49", "Age Group 45-49", "Grupo de Idade 45-49"),
+  AG_50_54("50-54", "Age Group 50-54", "Grupo de Idade 50-54"),
+  AG_55_59("55-59", "Age Group 55-59", "Grupo de Idade 55-59"),
+  AG_60_64("60-64", "Age Group 60-64", "Grupo de Idade 60-64"),
+  AG_65_69("65-69", "Age Group 65-69", "Grupo de Idade 65-69"),
+  AG_70_74("70-74", "Age Group 70-74", "Grupo de Idade 70-74"),
+  AG_75_79("75-79", "Age Group 75-79", "Grupo de Idade 75-79"),
+  AG_80_84("80-84", "Age Group 80-84", "Grupo de Idade 80-84"),
+  AG_85_89("85-89", "Age Group 85-89", "Grupo de Idade 85-89"),
+  AG_90_94("90-94", "Age Group 90-94", "Grupo de Idade 90-94"),
+  AG_95_99("95-99", "Age Group 95-99", "Grupo de Idade 95-99");
+
+  private final String code;
+  private final String denominationEN;
+  private final String denominationPT;
+
+  AgeGroup(String code, String denominationEN, String denominationPT) {
+    this.code = code;
+    this.denominationEN = denominationEN;
+    this.denominationPT = denominationPT;
+  }
+
+  /**
+   * Returns the persistence code of the age group (e.g., {@code "OPEN"}).
+   * <p>
+   * This value is used for persistence and API interchange.
+   *
+   * @return the age group code
+   */
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * Returns the English name of the age group (e.g., {@code "Open"}).
+   *
+   * @return the English age group name
+   */
+  public String getDenominationEN() {
+    return denominationEN;
+  }
+
+  /**
+   * Returns the European Portuguese name of the age group (e.g., {@code "Geral"}).
+   *
+   * @return the Portuguese age group name
+   */
+  public String getDenominationPT() {
+    return denominationPT;
+  }
+
+  @Override
+  public String toString() {
+    return code;
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/AthleteGender.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/AthleteGender.java
@@ -18,34 +18,51 @@
  * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
  */
 
-package com.endurancetrio.data.event.model.enumerator;
+package com.endurancetrio.data.competitor.model.enumerator;
 
-import com.endurancetrio.data.event.model.entity.Race;
+import com.endurancetrio.data.competitor.model.entity.Athlete;
 
 /**
- * The {@link RaceStatus} enum represents the status of a {@link Race}
+ * The {@link AthleteGender} enum represents the gender of an {@link Athlete}.
  * <p>
  * It includes the following constants:
  * <ul>
- *   <li>
- *     {@link #PLANNED} : used for the {@link Race races} that are planned but not yet
- *     (or were ever) completed.
- *   </li>
- *   <li>{@link #COMPLETED} : used for the {@link Race races} that were completed.</li>
+ *   <li>{@link #MALE} : used for male athletes.</li>
+ *   <li>{@link #FEMALE} : used for female athletes.</li>
  * </ul>
  */
-public enum RaceStatus {
-  PLANNED("PLANNED"),
-  COMPLETED("COMPLETED");
+public enum AthleteGender {
+  FEMALE("FEMALE", "F"),
+  MALE("MALE", "M");
 
   private final String code;
+  private final String shortCode;
 
-  RaceStatus(String code) {
+  AthleteGender(String code, String shortCode) {
     this.code = code;
+    this.shortCode = shortCode;
   }
 
+  /**
+   * Returns the full code of the gender (e.g., {@code "MALE"}, {@code "FEMALE"}).
+   * <p>
+   * This value is used for persistence and API interchange.
+   *
+   * @return the full gender code
+   */
   public String getCode() {
     return code;
+  }
+
+  /**
+   * Returns the short code of the gender (e.g., {@code "M"}, {@code "F"}).
+   * <p>
+   * This value is intended for compact display in UI tables, result sheets, and scoreboards.
+   *
+   * @return the short gender code
+   */
+  public String getShortCode() {
+    return shortCode;
   }
 
   @Override

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/Country.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/Country.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.enumerator;
+
+/**
+ * The {@link Country} enum represents a country using its National Olympic Committee (NOC) code.
+ * <p>
+ * Each constant includes the three-letter NOC code, the English full name, and the European
+ * Portuguese full name. The NOC code is used for persistence and API interchange, while the full
+ * names are available for display purposes in their respective languages.
+ */
+public enum Country {
+  AFG("AFG", "Afghanistan", "Afeganistão"),
+  ALB("ALB", "Albania", "Albânia"),
+  ALG("ALG", "Algeria", "Argélia"),
+  AND("AND", "Andorra", "Andorra"),
+  ANG("ANG", "Angola", "Angola"),
+  ANT("ANT", "Antigua and Barbuda", "Antígua e Barbuda"),
+  ARG("ARG", "Argentina", "Argentina"),
+  ARM("ARM", "Armenia", "Arménia"),
+  ARU("ARU", "Aruba", "Aruba"),
+  ASA("ASA", "American Samoa", "Samoa Americana"),
+  AUS("AUS", "Australia", "Austrália"),
+  AUT("AUT", "Austria", "Áustria"),
+  AZE("AZE", "Azerbaijan", "Azerbaijão"),
+  BAH("BAH", "Bahamas", "Bahamas"),
+  BAN("BAN", "Bangladesh", "Bangladesh"),
+  BAR("BAR", "Barbados", "Barbados"),
+  BDI("BDI", "Burundi", "Burundi"),
+  BEL("BEL", "Belgium", "Bélgica"),
+  BEN("BEN", "Benin", "Benim"),
+  BER("BER", "Bermuda", "Bermudas"),
+  BHU("BHU", "Bhutan", "Butão"),
+  BIH("BIH", "Bosnia and Herzegovina", "Bósnia e Herzegovina"),
+  BIZ("BIZ", "Belize", "Belize"),
+  BLR("BLR", "Belarus", "Bielorrússia"),
+  BOL("BOL", "Bolivia", "Bolívia"),
+  BOT("BOT", "Botswana", "Botsuana"),
+  BRA("BRA", "Brazil", "Brasil"),
+  BRN("BRN", "Bahrain", "Bahrein"),
+  BRU("BRU", "Brunei Darussalam", "Brunei"),
+  BUL("BUL", "Bulgaria", "Bulgária"),
+  BUR("BUR", "Burkina Faso", "Burkina Faso"),
+  CAF("CAF", "Central African Republic", "República Centro-Africana"),
+  CAM("CAM", "Cambodia", "Camboja"),
+  CAN("CAN", "Canada", "Canadá"),
+  CAY("CAY", "Cayman Islands", "Ilhas Caimão"),
+  CGO("CGO", "Congo", "Congo"),
+  CHA("CHA", "Chad", "Chade"),
+  CHI("CHI", "Chile", "Chile"),
+  CHN("CHN", "China", "China"),
+  CIV("CIV", "Côte d'Ivoire", "Costa do Marfim"),
+  CMR("CMR", "Cameroon", "Camarões"),
+  COD("COD", "Democratic Republic of the Congo", "República Democrática do Congo"),
+  COK("COK", "Cook Islands", "Ilhas Cook"),
+  COL("COL", "Colombia", "Colômbia"),
+  COM("COM", "Comoros", "Comores"),
+  CPV("CPV", "Cape Verde", "Cabo Verde"),
+  CRC("CRC", "Costa Rica", "Costa Rica"),
+  CRO("CRO", "Croatia", "Croácia"),
+  CUB("CUB", "Cuba", "Cuba"),
+  CYP("CYP", "Cyprus", "Chipre"),
+  CZE("CZE", "Czechia", "Chéquia"),
+  DEN("DEN", "Denmark", "Dinamarca"),
+  DJI("DJI", "Djibouti", "Jibuti"),
+  DMA("DMA", "Dominica", "Domínica"),
+  DOM("DOM", "Dominican Republic", "República Dominicana"),
+  ECU("ECU", "Ecuador", "Equador"),
+  EGY("EGY", "Egypt", "Egito"),
+  ERI("ERI", "Eritrea", "Eritreia"),
+  ESA("ESA", "El Salvador", "El Salvador"),
+  ESP("ESP", "Spain", "Espanha"),
+  EST("EST", "Estonia", "Estónia"),
+  ETH("ETH", "Ethiopia", "Etiópia"),
+  FIJ("FIJ", "Fiji", "Fiji"),
+  FIN("FIN", "Finland", "Finlândia"),
+  FRA("FRA", "France", "França"),
+  FSM("FSM", "Federated States of Micronesia", "Estados Federados da Micronésia"),
+  GAB("GAB", "Gabon", "Gabão"),
+  GAM("GAM", "Gambia", "Gâmbia"),
+  GBR("GBR", "Great Britain", "Grã-Bretanha"),
+  GBS("GBS", "Guinea-Bissau", "Guiné-Bissau"),
+  GEO("GEO", "Georgia", "Geórgia"),
+  GEQ("GEQ", "Equatorial Guinea", "Guiné Equatorial"),
+  GER("GER", "Germany", "Alemanha"),
+  GHA("GHA", "Ghana", "Gana"),
+  GRE("GRE", "Greece", "Grécia"),
+  GRN("GRN", "Grenada", "Granada"),
+  GUA("GUA", "Guatemala", "Guatemala"),
+  GUI("GUI", "Guinea", "Guiné"),
+  GUM("GUM", "Guam", "Guame"),
+  GUY("GUY", "Guyana", "Guiana"),
+  HAI("HAI", "Haiti", "Haiti"),
+  HKG("HKG", "Hong Kong, China", "Hong Kong, China"),
+  HON("HON", "Honduras", "Honduras"),
+  HUN("HUN", "Hungary", "Hungria"),
+  INA("INA", "Indonesia", "Indonésia"),
+  IND("IND", "India", "Índia"),
+  IRL("IRL", "Ireland", "Irlanda"),
+  IRI("IRI", "Iran", "Irão"),
+  IRQ("IRQ", "Iraq", "Iraque"),
+  ISL("ISL", "Iceland", "Islândia"),
+  ISR("ISR", "Israel", "Israel"),
+  ISV("ISV", "Virgin Islands, US", "Ilhas Virgens Americanas"),
+  ITA("ITA", "Italy", "Itália"),
+  IVB("IVB", "British Virgin Islands", "Ilhas Virgens Britânicas"),
+  JAM("JAM", "Jamaica", "Jamaica"),
+  JOR("JOR", "Jordan", "Jordânia"),
+  JPN("JPN", "Japan", "Japão"),
+  KAZ("KAZ", "Kazakhstan", "Cazaquistão"),
+  KEN("KEN", "Kenya", "Quénia"),
+  KGZ("KGZ", "Kyrgyzstan", "Quirguistão"),
+  KIR("KIR", "Kiribati", "Quiribáti"),
+  KOR("KOR", "Republic of Korea", "Coreia do Sul"),
+  KOS("KOS", "Kosovo", "Kosovo"),
+  KSA("KSA", "Saudi Arabia", "Arábia Saudita"),
+  KUW("KUW", "Kuwait", "Kuwait"),
+  LAO("LAO", "Laos", "Laos"),
+  LAT("LAT", "Latvia", "Letónia"),
+  LBA("LBA", "Libya", "Líbia"),
+  LBN("LBN", "Lebanon", "Líbano"),
+  LBR("LBR", "Liberia", "Libéria"),
+  LCA("LCA", "Saint Lucia", "Santa Lúcia"),
+  LES("LES", "Lesotho", "Lesoto"),
+  LIE("LIE", "Liechtenstein", "Liechtenstein"),
+  LTU("LTU", "Lithuania", "Lituânia"),
+  LUX("LUX", "Luxembourg", "Luxemburgo"),
+  MAD("MAD", "Madagascar", "Madagáscar"),
+  MAR("MAR", "Morocco", "Marrocos"),
+  MAS("MAS", "Malaysia", "Malásia"),
+  MAW("MAW", "Malawi", "Maláui"),
+  MDA("MDA", "Republic of Moldova", "Moldávia"),
+  MDV("MDV", "Maldives", "Maldivas"),
+  MEX("MEX", "Mexico", "México"),
+  MGL("MGL", "Mongolia", "Mongólia"),
+  MHL("MHL", "Marshall Islands", "Ilhas Marshall"),
+  MKD("MKD", "North Macedonia", "Macedónia do Norte"),
+  MLI("MLI", "Mali", "Mali"),
+  MLT("MLT", "Malta", "Malta"),
+  MNE("MNE", "Montenegro", "Montenegro"),
+  MON("MON", "Monaco", "Mónaco"),
+  MOZ("MOZ", "Mozambique", "Moçambique"),
+  MRI("MRI", "Mauritius", "Maurícia"),
+  MTN("MTN", "Mauritania", "Mauritânia"),
+  MYA("MYA", "Myanmar", "Mianmar"),
+  NAM("NAM", "Namibia", "Namíbia"),
+  NCA("NCA", "Nicaragua", "Nicarágua"),
+  NED("NED", "Netherlands", "Países Baixos"),
+  NEP("NEP", "Nepal", "Nepal"),
+  NGR("NGR", "Nigeria", "Nigéria"),
+  NIG("NIG", "Niger", "Níger"),
+  NOR("NOR", "Norway", "Noruega"),
+  NRU("NRU", "Nauru", "Nauru"),
+  NZL("NZL", "New Zealand", "Nova Zelândia"),
+  OMA("OMA", "Oman", "Omã"),
+  PAK("PAK", "Pakistan", "Paquistão"),
+  PAN("PAN", "Panama", "Panamá"),
+  PAR("PAR", "Paraguay", "Paraguai"),
+  PER("PER", "Peru", "Peru"),
+  PHI("PHI", "Philippines", "Filipinas"),
+  PLE("PLE", "Palestine", "Palestina"),
+  PLW("PLW", "Palau", "Palau"),
+  PNG("PNG", "Papua New Guinea", "Papua-Nova Guiné"),
+  POL("POL", "Poland", "Polónia"),
+  POR("POR", "Portugal", "Portugal"),
+  PRK("PRK", "Democratic People's Republic of Korea", "Coreia do Norte"),
+  PUR("PUR", "Puerto Rico", "Porto Rico"),
+  QAT("QAT", "Qatar", "Catar"),
+  ROU("ROU", "Romania", "Roménia"),
+  RSA("RSA", "South Africa", "África do Sul"),
+  RUS("RUS", "Russia", "Rússia"),
+  RWA("RWA", "Rwanda", "Ruanda"),
+  SAM("SAM", "Samoa", "Samoa"),
+  SEN("SEN", "Senegal", "Senegal"),
+  SEY("SEY", "Seychelles", "Seicheles"),
+  SGP("SGP", "Singapore", "Singapura"),
+  SKN("SKN", "Saint Kitts and Nevis", "São Cristóvão e Neves"),
+  SLE("SLE", "Sierra Leone", "Serra Leoa"),
+  SLO("SLO", "Slovenia", "Eslovénia"),
+  SMR("SMR", "San Marino", "São Marinho"),
+  SOL("SOL", "Solomon Islands", "Ilhas Salomão"),
+  SOM("SOM", "Somalia", "Somália"),
+  SRB("SRB", "Serbia", "Sérvia"),
+  SRI("SRI", "Sri Lanka", "Sri Lanka"),
+  SSD("SSD", "South Sudan", "Sudão do Sul"),
+  STP("STP", "Sao Tome and Principe", "São Tomé e Príncipe"),
+  SUD("SUD", "Sudan", "Sudão"),
+  SUI("SUI", "Switzerland", "Suíça"),
+  SUR("SUR", "Suriname", "Suriname"),
+  SVK("SVK", "Slovakia", "Eslováquia"),
+  SWE("SWE", "Sweden", "Suécia"),
+  SWZ("SWZ", "Eswatini", "Eswatini"),
+  SYR("SYR", "Syrian Arab Republic", "Síria"),
+  TAN("TAN", "Tanzania", "Tanzânia"),
+  TGA("TGA", "Tonga", "Tonga"),
+  THA("THA", "Thailand", "Tailândia"),
+  TJK("TJK", "Tajikistan", "Tajiquistão"),
+  TKM("TKM", "Turkmenistan", "Turquemenistão"),
+  TLS("TLS", "Timor-Leste", "Timor-Leste"),
+  TOG("TOG", "Togo", "Togo"),
+  TPE("TPE", "Chinese Taipei", "Taipé Chinês"),
+  TTO("TTO", "Trinidad and Tobago", "Trindade e Tobago"),
+  TUN("TUN", "Tunisia", "Tunísia"),
+  TUR("TUR", "Türkiye", "Turquia"),
+  TUV("TUV", "Tuvalu", "Tuvalu"),
+  UAE("UAE", "United Arab Emirates", "Emirados Árabes Unidos"),
+  UGA("UGA", "Uganda", "Uganda"),
+  UKR("UKR", "Ukraine", "Ucrânia"),
+  URU("URU", "Uruguay", "Uruguai"),
+  USA("USA", "United States of America", "Estados Unidos da América"),
+  UZB("UZB", "Uzbekistan", "Usbequistão"),
+  VAN("VAN", "Vanuatu", "Vanuatu"),
+  VEN("VEN", "Venezuela", "Venezuela"),
+  VIE("VIE", "Vietnam", "Vietname"),
+  VIN("VIN", "Saint Vincent and the Grenadines", "São Vicente e Granadinas"),
+  YEM("YEM", "Yemen", "Iémen"),
+  ZAM("ZAM", "Zambia", "Zâmbia"),
+  ZIM("ZIM", "Zimbabwe", "Zimbabué");
+
+  private final String code;
+  private final String nameEN;
+  private final String namePT;
+
+  Country(String code, String nameEN, String namePT) {
+    this.code = code;
+    this.nameEN = nameEN;
+    this.namePT = namePT;
+  }
+
+  /**
+   * Returns the three-letter NOC code of the country (e.g., {@code "POR"}, {@code "USA"}).
+   * <p>
+   * This value is used for persistence and API interchange.
+   *
+   * @return the NOC code
+   */
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * Returns the English full name of the country (e.g., {@code "Portugal"},
+   * {@code "United States of America"}).
+   * <p>
+   * This value is intended for display in English-language contexts and is always available from
+   * the enum instance without requiring a database join.
+   *
+   * @return the English full country name
+   */
+  public String getNameEN() {
+    return nameEN;
+  }
+
+  /**
+   * Returns the European Portuguese full name of the country (e.g., {@code "Portugal"},
+   * {@code "Estados Unidos da América"}).
+   * <p>
+   * This value is intended for display in Portuguese-language contexts and is always available
+   * from the enum instance without requiring a database join.
+   *
+   * @return the Portuguese full country name
+   */
+  public String getNamePT() {
+    return namePT;
+  }
+
+  @Override
+  public String toString() {
+    return code;
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/ParaClass.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/competitor/model/enumerator/ParaClass.java
@@ -1,0 +1,583 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.enumerator;
+
+/**
+ * The {@link ParaClass} enum represents sport classifications for multiple Paralympic disciplines.
+ * <p>
+ * The constants are grouped by sport using the following prefixes:
+ * <dl>
+ *   <dt>{@code AQ_}</dt><dd>World Para Aquatics (open water swimming)</dd>
+ *   <dt>{@code UC_}</dt><dd>UCI Para Cycling (road events)</dd>
+ *   <dt>{@code AT_}</dt><dd>World Para Athletics (road running)</dd>
+ *   <dt>{@code WT_}</dt><dd>World Triathlon (paratriathlon)</dd>
+ * </dl>
+ * Each constant includes a persistence code, an English name, and a European Portuguese name.
+ * The code is used for persistence and API interchange, while the full names are available for
+ * display purposes in their respective languages.
+ */
+public enum ParaClass {
+
+  // World Para Aquatics (Open Water Swimming)
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Open water swimming class for athletes with the most severe physical impairment, affecting all
+   * four limbs with minimal movement.
+   */
+  AQ_S1("S1", "Open Water, Minimal Limb Movement", "Águas Abertas, Movimento Mínimo dos Membros"),
+
+  /**
+   * Open water swimming class for athletes with a severe physical impairment, primarily using arm
+   * movement with limited leg and trunk function.
+   */
+  AQ_S2("S2", "Open Water, Primarily Arms", "Águas Abertas, Maioritariamente Braços"),
+
+  /**
+   * Open water swimming class for athletes with a severe physical impairment, able to use arms and
+   * slight leg movement.
+   */
+  AQ_S3("S3", "Open Water, Arms and Slight Legs", "Águas Abertas, Braços e Ligeiras Pernas"),
+
+  /**
+   * Open water swimming class for athletes with a moderate to severe physical impairment, using
+   * arms and moderate leg and trunk function.
+   */
+  AQ_S4("S4", "Open Water, Moderate to Severe Impairment",
+      "Águas Abertas, Deficiência Moderada a Grave"
+  ),
+
+  /**
+   * Open water swimming class for athletes with a moderate physical impairment, typically using
+   * arms and trunk with limited leg propulsion.
+   */
+  AQ_S5("S5", "Open Water, Arms and Trunk with Limited Legs",
+      "Águas Abertas, Braços e Tronco com Pernas Limitadas"
+  ),
+
+  /**
+   * Open water swimming class for athletes with a moderate physical impairment, with better trunk
+   * and leg function than S5.
+   */
+  AQ_S6("S6", "Open Water, Better Trunk and Leg Function",
+      "Águas Abertas, Melhor Função de Tronco e Pernas"
+  ),
+
+  /**
+   * Open water swimming class for athletes with a moderate to mild physical impairment, with
+   * functional use of arms, trunk, and legs.
+   */
+  AQ_S7("S7", "Open Water, Functional Arms, Trunk and Legs",
+      "Águas Abertas, Braços, Tronco e Pernas Funcionais"
+  ),
+
+  /**
+   * Open water swimming class for athletes with a mild physical impairment, such as a single
+   * below-knee amputation or comparable limitation.
+   */
+  AQ_S8("S8", "Open Water, Single Below-Knee", "Águas Abertas, Abaixo do Joelho (Simples)"),
+
+  /**
+   * Open water swimming class for athletes with a mild physical impairment, such as a single
+   * below-elbow amputation or comparable limitation.
+   */
+  AQ_S9("S9", "Open Water, Single Below-Elbow", "Águas Abertas, Abaixo do Cotovelo (Simples)"),
+
+  /**
+   * Open water swimming class for athletes with the least severe physical impairment, such as minor
+   * loss of function in one joint.
+   */
+  AQ_S10("S10", "Open Water, Minimal Physical Impairment",
+      "Águas Abertas, Deficiência Física Mínima"
+  ),
+
+  /**
+   * Open water swimming class for athletes who are totally blind.
+   * <p>
+   * Athletes require a tapper (person who taps them at the turn and finish walls).
+   */
+  AQ_S11("S11", "Open Water, Blind", "Águas Abertas, Cegueira"),
+
+  /**
+   * Open water swimming class for athletes with severe vision impairment.
+   * <p>
+   * Athletes typically have a visual acuity of LogMAR 1.50 to 2.60.
+   */
+  AQ_S12("S12", "Open Water, Severe Vision Impairment", "Águas Abertas, Deficiência Visual Grave"),
+
+  /**
+   * Open water swimming class for athletes with moderate vision impairment.
+   * <p>
+   * Athletes typically have a visual acuity of LogMAR 1.00 to 1.40.
+   */
+  AQ_S13("S13", "Open Water, Moderate Vision Impairment",
+      "Águas Abertas, Deficiência Visual Moderada"
+  ),
+
+  /**
+   * Open water swimming class for athletes with an intellectual impairment.
+   * <p>
+   * Requires to be documented IQ ≤ 75 with significant limitations in adaptive behavior.
+   */
+  AQ_S14("S14", "Open Water, Intellectual Impairment", "Águas Abertas, Deficiência Intelectual"),
+
+  // UCI Para Cycling (Road)
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Road cycling class for athletes with the most severe impairment affecting all four limbs, using
+   * a standard bicycle with adaptations.
+   */
+  UC_C1("C1", "Road Cycling, Severe Physical Impairment",
+      "Ciclismo de Estrada, Deficiência Física Grave"
+  ),
+
+  /**
+   * Road cycling class for athletes with a severe impairment affecting lower or upper limbs, using
+   * a standard bicycle with adaptations.
+   */
+  UC_C2("C2", "Road Cycling, Moderate to Severe Impairment",
+      "Ciclismo de Estrada, Deficiência Moderada a Grave"
+  ),
+
+  /**
+   * Road cycling class for athletes with a moderate impairment, such as a single above-knee
+   * amputation, using a standard bicycle with adaptations.
+   */
+  UC_C3("C3", "Road Cycling, Moderate Impairment", "Ciclismo de Estrada, Deficiência Moderada"),
+
+  /**
+   * Road cycling class for athletes with a mild impairment, such as a single below-knee amputation,
+   * using a standard bicycle with adaptations.
+   */
+  UC_C4("C4", "Road Cycling, Mild Impairment", "Ciclismo de Estrada, Deficiência Leve"),
+
+  /**
+   * Road cycling class for athletes with the least severe impairment, such as a minor loss of hand
+   * or foot function, using a standard bicycle.
+   */
+  UC_C5("C5", "Road Cycling, Minimal Impairment", "Ciclismo de Estrada, Deficiência Mínima"),
+
+  /**
+   * Road handcycle class for athletes with tetraplegia at C1–C6 level or comparable impairment,
+   * using a recumbent handcycle operated primarily with arm movement.
+   */
+  UC_H1("H1", "Road Handcycle, Tetraplegia C1-C6", "Handcycle de Estrada, Tetraplegia C1-C6"),
+
+  /**
+   * Road handcycle class for athletes with tetraplegia at C7–T3 level or comparable impairment,
+   * using a recumbent handcycle with arm and limited trunk function.
+   */
+  UC_H2("H2", "Road Handcycle, Tetraplegia C7-T3", "Handcycle de Estrada, Tetraplegia C7-T3"),
+
+  /**
+   * Road handcycle class for athletes with paraplegia at T4–T10 level or comparable impairment,
+   * using a recumbent handcycle with full arm function.
+   */
+  UC_H3("H3", "Road Handcycle, Paraplegia T4-T10", "Handcycle de Estrada, Paraplegia T4-T10"),
+
+  /**
+   * Road handcycle class for athletes with paraplegia at T11–S5 level or comparable impairment,
+   * using a recumbent handcycle with full arm and partial trunk function.
+   */
+  UC_H4("H4", "Road Handcycle, Paraplegia T11-S5", "Handcycle de Estrada, Paraplegia T11-S5"),
+
+  /**
+   * Road handcycle class for athletes with lower limb impairments who ride in a kneeling position
+   * on a handcycle, typically for those with bilateral above-knee amputations.
+   */
+  UC_H5("H5", "Road Handcycle, Kneeling Position", "Handcycle de Estrada, Posição de Joelhos"),
+
+  /**
+   * Road tricycle class for athletes with a severe coordination impairment affecting all four
+   * limbs, requiring a three-wheeled tricycle for stability.
+   */
+  UC_T1("T1", "Road Tricycle, Severe Coordination Impairment",
+      "Triciclo de Estrada, Deficiência Coordenação Grave"
+  ),
+
+  /**
+   * Road tricycle class for athletes with a moderate coordination impairment, using a three-wheeled
+   * tricycle for stability.
+   */
+  UC_T2("T2", "Road Tricycle, Moderate Coordination Impairment",
+      "Triciclo de Estrada, Deficiência Coordenação Moderada"
+  ),
+
+  /**
+   * Road tandem cycling class for athletes with a vision impairment, without further subclass
+   * distinction.
+   * <p>
+   * Competes on a tandem bicycle with a sighted pilot.
+   */
+  UC_B("B", "Road Tandem, Visually Impaired", "Tandem de Estrada, Deficiência Visual"),
+
+  /**
+   * Road tandem cycling class for athletes who are totally blind.
+   * <p>
+   * Corresponds to a B1 visual acuity of less than LogMAR 2.60.
+   */
+  UC_B1("B1", "Road Tandem, Blind", "Tandem de Estrada, Cegueira"),
+
+  /**
+   * Road tandem cycling class for athletes with severe partial sight.
+   * <p>
+   * Corresponds to a B2 visual acuity ranging from LogMAR 1.50 to 2.60.
+   */
+  UC_B2("B2", "Road Tandem, Severe Vision Impairment",
+      "Tandem de Estrada, Deficiência Visual Grave"
+  ),
+
+  /**
+   * Road tandem cycling class for athletes with moderate partial sight.
+   * <p>
+   * Corresponds to a B3 visual acuity ranging from LogMAR 1.00 to 1.40.
+   */
+  UC_B3("B3", "Road Tandem, Moderate Vision Impairment",
+      "Tandem de Estrada, Deficiência Visual Moderada"
+  ),
+
+  // World Para Athletics (Road Running)
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Road running class for athletes with a vision impairment classified as B1.
+   * <p>
+   * Athletes are totally blind and must run with a guide.
+   */
+  AT_T11("T11", "Road, Vision Impairment B1", "Estrada, Deficiência Visual B1"),
+
+  /**
+   * Road running class for athletes with a vision impairment classified as B2.
+   * <p>
+   * Athletes have severe partial sight and may run with a guide.
+   */
+  AT_T12("T12", "Road, Vision Impairment B2", "Estrada, Deficiência Visual B2"),
+
+  /**
+   * Road running class for athletes with a vision impairment classified as B3.
+   * <p>
+   * Athletes have moderate partial sight and run without a guide.
+   */
+  AT_T13("T13", "Road, Vision Impairment B3", "Estrada, Deficiência Visual B3"),
+
+  /**
+   * Road running class for athletes with an intellectual impairment.
+   * <p>
+   * Requires to be documented IQ ≤ 75 with significant limitations in adaptive behavior.
+   */
+  AT_T20("T20", "Road, Intellectual Impairment", "Estrada, Deficiência Intelectual"),
+
+  /**
+   * Road running class for ambulant athletes with a coordination impairment (hypertonia, ataxia, or
+   * athetosis) affecting lower limbs, most severe in this group.
+   */
+  AT_T35("T35", "Road, Coordination Most Severe", "Estrada, Coordenação Mais Grave"),
+
+  /**
+   * Road running class for ambulant athletes with a coordination impairment (hypertonia, ataxia, or
+   * athetosis) affecting all four limbs.
+   */
+  AT_T36("T36", "Road, Coordination Quadruple", "Estrada, Coordenação Quádrupla"),
+
+  /**
+   * Road running class for ambulant athletes with a coordination impairment (hemiplegia) affecting
+   * one side of the body.
+   */
+  AT_T37("T37", "Road, Coordination Hemiplegic", "Estrada, Coordenação Hemiplegia"),
+
+  /**
+   * Road running class for ambulant athletes with a coordination impairment (hypertonia, ataxia, or
+   * athetosis) affecting one or both limbs, least severe in this group.
+   */
+  AT_T38("T38", "Road, Coordination Least Severe", "Estrada, Coordenação Menos Grave"),
+
+  /**
+   * Road running class for athletes of short stature (dwarfism).
+   * <p>
+   * Covers the most severe short stature conditions.
+   */
+  AT_T40("T40", "Road, Short Stature Severe", "Estrada, Baixa Estatura Grave"),
+
+  /**
+   * Road running class for athletes of short stature (dwarfism).
+   * <p>
+   * Covers less severe short stature conditions than T40.
+   */
+  AT_T41("T41", "Road, Short Stature Less Severe", "Estrada, Baixa Estatura Menos Grave"),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete without a prosthesis.
+   * <p>
+   * Covers single above-knee amputation or comparable impairment.
+   */
+  AT_T42("T42", "Road, Lower Limb Single Above-Knee",
+      "Estrada, Membro Inferior Acima do Joelho (Simples)"
+  ),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete without a prosthesis.
+   * <p>
+   * Covers double below-knee amputation or comparable impairment.
+   */
+  AT_T43("T43", "Road, Lower Limb Double Below-Knee",
+      "Estrada, Membros Inferiores Abaixo do Joelho (Duplo)"
+  ),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete without a prosthesis.
+   * <p>
+   * Covers single below-knee amputation or comparable impairment.
+   */
+  AT_T44("T44", "Road, Lower Limb Single Below-Knee",
+      "Estrada, Membro Inferior Abaixo do Joelho (Simples)"
+  ),
+
+  /**
+   * Road running class for athletes with an upper limb impairment affecting both arms.
+   */
+  AT_T45("T45", "Road, Upper Limb Bilateral", "Estrada, Membro Superior Bilateral"),
+
+  /**
+   * Road running class for athletes with an upper limb impairment affecting one arm.
+   */
+  AT_T46("T46", "Road, Upper Limb Unilateral", "Estrada, Membro Superior Unilateral"),
+
+  /**
+   * Road running class for athletes with an upper limb impairment (combined single-arm category).
+   * <p>
+   * Replaces the former T45 and T46 subclasses in current classification.
+   */
+  AT_T47("T47", "Road, Upper Limb Combined", "Estrada, Membro Superior Combinado"),
+
+  /**
+   * Wheelchair road racing class for athletes with the most severe impairments, typically involving
+   * reduced shoulder, arm, and hand function.
+   */
+  AT_T51("T51", "Road, Wheelchair Minimal Trunk Function",
+      "Estrada, Cadeira de Rodas Função Mínima de Tronco"
+  ),
+
+  /**
+   * Wheelchair road racing class for athletes with moderate to severe impairment affecting
+   * shoulder, arm, and hand function.
+   */
+  AT_T52("T52", "Road, Wheelchair Limited Trunk Function",
+      "Estrada, Cadeira de Rodas Função Limitada de Tronco"
+  ),
+
+  /**
+   * Wheelchair road racing class for athletes with good shoulder and arm function but limited trunk
+   * and leg function.
+   */
+  AT_T53("T53", "Road, Wheelchair Good Arm Function",
+      "Estrada, Cadeira de Rodas Boa Função dos Braços"
+  ),
+
+  /**
+   * Wheelchair road racing class for athletes with full shoulder, arm, and trunk function,
+   * typically with some leg function.
+   */
+  AT_T54("T54", "Road, Wheelchair Full Trunk Function",
+      "Estrada, Cadeira de Rodas Função Completa do Tronco"
+  ),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete with a prosthesis,
+   * single above-knee.
+   */
+  AT_T61("T61", "Road, Prosthesis Single Above-Knee",
+      "Estrada, Prótese Acima do Joelho (Simples)"
+  ),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete with a prosthesis,
+   * double below-knee.
+   */
+  AT_T62("T62", "Road, Prosthesis Double Below-Knee",
+      "Estrada, Prótese Abaixo do Joelho (Dupla)"
+  ),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete with a prosthesis,
+   * single below-knee.
+   */
+  AT_T63("T63", "Road, Prosthesis Single Below-Knee",
+      "Estrada, Prótese Abaixo do Joelho (Simples)"
+  ),
+
+  /**
+   * Road running class for athletes with a lower limb impairment who compete with a prosthesis,
+   * single below-knee or comparable, least severe in this group.
+   */
+  AT_T64("T64", "Road, Prosthesis Least Severe", "Estrada, Prótese Menos Grave"),
+
+  /**
+   * Road running class for athletes who compete using a frame runner (three-wheel support frame),
+   * most severe impairment in this group.
+   */
+  AT_T71("T71", "Road, Frame Running More Severe", "Estrada, Corrida com Apoio Mais Grave"),
+
+  /**
+   * Road running class for athletes who compete using a frame runner (three-wheel support frame),
+   * less severe impairment in this group.
+   */
+  AT_T72("T72", "Road, Frame Running Less Severe", "Estrada, Corrida com Apoio Menos Grave"),
+
+  // World Triathlon (Paratriathlon)
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * Paratriathlon class for athletes with an intellectual impairment.
+   * <p>
+   * Covers athletes with an IQ ≤ 75 and significant limitations in adaptive behavior. Used by the
+   * Portuguese Triathlon Federation for national competitions.
+   */
+  WT_PTII("PTII", "Intellectual Impairment", "Deficiência Intelectual"),
+
+  /**
+   * Paratriathlon class for athletes with a hearing impairment.
+   * <p>
+   * Used by the Portuguese Triathlon Federation for national competitions.
+   */
+  WT_PTHI("PTHI", "Hearing Impairment", "Deficiência Auditiva"),
+
+  /**
+   * Paratriathlon class for athletes with a severe impairment in at least two of the three
+   * disciplines (swim, bike, run).
+   * <p>
+   * Typically includes wheelchair users on the bike (handcycle) and run (racing wheelchair).
+   */
+  WT_PTS2("PTS2", "Severe Impairment", "Deficiência Grave"),
+
+  /**
+   * Paratriathlon class for athletes with a significant impairment affecting one or more
+   * disciplines.
+   * <p>
+   * May use a handcycle for the bike leg and/or a wheelchair for the run leg.
+   */
+  WT_PTS3("PTS3", "Significant Impairment", "Deficiência Significativa"),
+
+  /**
+   * Paratriathlon class for athletes with a moderate impairment in one or more disciplines.
+   * <p>
+   * Ambulant athletes who may use prosthetics or other assistive devices.
+   */
+  WT_PTS4("PTS4", "Moderate Impairment", "Deficiência Moderada"),
+
+  /**
+   * Paratriathlon class for athletes with a mild impairment in one or more disciplines.
+   * <p>
+   * Ambulant athletes with the least severe physical impairment in this category.
+   */
+  WT_PTS5("PTS5", "Mild Impairment", "Deficiência Leve"),
+
+  /**
+   * Paratriathlon class for athletes who compete using a wheelchair in the run segment and a
+   * handcycle in the bike segment, without further subclass distinction.
+   */
+  WT_PTWC("PTWC", "Wheelchair User", "Utilizador de Cadeira de Rodas"),
+
+  /**
+   * Paratriathlon wheelchair class for athletes with the most severe impairments, including
+   * tetraplegia and comparable disabilities.
+   */
+  WT_PTWC1("PTWC1", "Wheelchair, Severe Impairment", "Cadeira de Rodas, Deficiência Grave"),
+
+  /**
+   * Paratriathlon wheelchair class for athletes with less severe impairments compared to PTWC1,
+   * including paraplegia and comparable disabilities.
+   */
+  WT_PTWC2("PTWC2", "Wheelchair, Moderate Impairment", "Cadeira de Rodas, Deficiência Moderada"),
+
+  /**
+   * Paratriathlon class for athletes with a vision impairment, without further subclass
+   * distinction.
+   * <p>
+   * Competes with a guide of the same sex and uses a tether during the swim and run legs.
+   */
+  WT_PTVI("PTVI", "Vision Impaired", "Deficiência Visual"),
+
+  /**
+   * Paratriathlon vision impairment class for athletes who are totally blind.
+   * <p>
+   * Corresponds to a B1 visual acuity of less than LogMAR 2.60.
+   */
+  WT_PTVI1("PTVI1", "Totally Blind", "Cegueira Total"),
+
+  /**
+   * Paratriathlon vision impairment class for athletes with severe partial sight.
+   * <p>
+   * Corresponds to a B2 visual acuity ranging from LogMAR 1.50 to 2.60.
+   */
+  WT_PTVI2("PTVI2", "Severely Partially Sighted", "Deficiência Visual Parcial Grave"),
+
+  /**
+   * Paratriathlon vision impairment class for athletes with moderate partial sight.
+   * <p>
+   * Corresponds to a B3 visual acuity ranging from LogMAR 1.00 to 1.40.
+   */
+  WT_PTVI3("PTVI3", "Moderately Partially Sighted", "Deficiência Visual Parcial Moderada");
+
+  private final String code;
+  private final String denominationEN;
+  private final String denominationPT;
+
+  ParaClass(String code, String denominationEN, String denominationPT) {
+    this.code = code;
+    this.denominationEN = denominationEN;
+    this.denominationPT = denominationPT;
+  }
+
+  /**
+   * Returns the persistence code of the para class (e.g., {@code "PTVI"}).
+   * <p>
+   * This value is used for persistence and API interchange.
+   *
+   * @return the para class code
+   */
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * Returns the English name of the para class (e.g., {@code "Vision Impaired"}).
+   *
+   * @return the English para class name
+   */
+  public String getDenominationEN() {
+    return denominationEN;
+  }
+
+  /**
+   * Returns the European Portuguese name of the para class (e.g., {@code "Deficiência Visual"}).
+   *
+   * @return the Portuguese para class name
+   */
+  public String getNamePT() {
+    return denominationPT;
+  }
+
+  @Override
+  public String toString() {
+    return code;
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/converter/DurationToIntegerConverter.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/converter/DurationToIntegerConverter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * The {@link DurationToIntegerConverter} class is responsible for converting {@link Duration}
+ * values to their corresponding database column representation (milliseconds) and vice versa.
+ * <p>
+ * This converter is used to persist {@link Duration} fields as an {@link Integer} of milliseconds
+ * in the database. It converts the {@link Duration} to its total milliseconds when storing it and
+ * converts the milliseconds back to a {@link Duration} when retrieving it from the database.
+ */
+@Converter
+public class DurationToIntegerConverter implements AttributeConverter<Duration, Integer> {
+
+  @Override
+  public Integer convertToDatabaseColumn(Duration duration) {
+    return Optional.ofNullable(duration).map(d -> (int) d.toMillis()).orElse(null);
+  }
+
+  @Override
+  public Duration convertToEntityAttribute(Integer milliseconds) {
+    return Optional.ofNullable(milliseconds).map(Duration::ofMillis).orElse(null);
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/converter/PenaltyConverter.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/converter/PenaltyConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import com.endurancetrio.data.event.model.enumerator.Penalty;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * The {@link PenaltyConverter} class is responsible for converting the {@link Penalty} enum to its
+ * corresponding database column representation and vice versa.
+ * <p>
+ * This converter is used to persist the {@link Penalty} enum as a string in the database. It
+ * converts the enum to its code when storing it in the database and converts the code back to the
+ * enum when retrieving it from the database.
+ */
+@Converter
+public class PenaltyConverter implements AttributeConverter<Penalty, String> {
+
+  @Override
+  public String convertToDatabaseColumn(Penalty penalty) {
+    return Optional.ofNullable(penalty).map(Penalty::getCode).orElse(null);
+  }
+
+  @Override
+  public Penalty convertToEntityAttribute(String code) {
+    return Stream.of(Penalty.values())
+        .filter(penalty -> penalty.getCode().equals(code.toUpperCase()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            String.format("The value '%s' returned from the database is not valid", code)));
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/IndividualResult.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/IndividualResult.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.entity;
+
+import com.endurancetrio.data.common.model.entity.BaseEntity;
+import com.endurancetrio.data.competitor.model.converter.AgeGroupConverter;
+import com.endurancetrio.data.competitor.model.converter.ParaClassConverter;
+import com.endurancetrio.data.competitor.model.entity.Athlete;
+import com.endurancetrio.data.competitor.model.entity.Team;
+import com.endurancetrio.data.competitor.model.enumerator.AgeGroup;
+import com.endurancetrio.data.competitor.model.enumerator.ParaClass;
+import com.endurancetrio.data.event.model.converter.DurationToIntegerConverter;
+import com.endurancetrio.data.event.model.converter.PenaltyConverter;
+import com.endurancetrio.data.event.model.enumerator.Penalty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.io.Serial;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+/**
+ * The {@link IndividualResult} entity represents a single athlete's result in a {@link Race}.
+ * <p>
+ * Common fields include {@link #getRace() race} reference, the athlete's {@link #getRank() rank},
+ * and the {@link #getSourceResult() sourceResult} for derived race linking. Performance data
+ * is stored as split times for each discipline segment.
+ * <p>
+ * The {@link IndividualResult}'s fields are defined as follows:
+ * <ul>
+ *   <li>
+ *     {@link #getId() id} : the unique identifier of the {@link IndividualResult} that
+ *     is automatically generated and is the primary key.
+ *   </li>
+ *   <li>
+ *     {@link #getRace() race} : the {@link Race} that this result belongs to.
+ *   </li>
+ *   <li>
+ *     {@link #getRank() rank} : the athlete's finishing position in this {@link Race}.
+ *   </li>
+ *   <li>
+ *     {@link #getSourceResult() sourceResult} : the parent {@link IndividualResult} that this
+ *     result is derived from, if any. Performance data should be read from this source
+ *     for derived race results.
+ *   </li>
+ *   <li>
+ *     {@link #getPenalty() penalty} : the {@link Penalty} applied to the athlete in this
+ *     {@link Race} (e.g., DNF, DSQ, DNS).
+ *   </li>
+ *   <li>
+ *     {@link #getAthlete() athlete} : the {@link Athlete} this result belongs to.
+ *   </li>
+ *   <li>
+ *     {@link #getTeam() team} : the {@link Team} this result belongs to, if applicable.
+ *   </li>
+ *   <li>
+ *     {@link #getTeamName() teamName} : the display name of the {@link Team} as it appears
+ *     in this specific {@link Race}. May differ from the team's canonical name.
+ *   </li>
+ *   <li>
+ *     {@link #getAgeGroup() ageGroup} : the {@link AgeGroup} of the athlete for this
+ *     specific {@link Race}.
+ *   </li>
+ *   <li>
+ *     {@link #getParaClass() paraClass} : the paratriathlon sport {@link ParaClass} of the
+ *     athlete for this specific {@link Race}.
+ *   </li>
+ *   <li>
+ *     {@link #getBib() bib} : the athlete's race bib number.
+ *   </li>
+ *   <li>
+ *     {@link #getSwim() swim} : the swim split time.
+ *   </li>
+ *   <li>
+ *     {@link #getFirstBike() firstBike} : the first bike split time
+ *     (for double-biathlon based disciplines).
+ *   </li>
+ *   <li>
+ *     {@link #getFirstRun() firstRun} : the first run split time
+ *     (for duathlon and double-biathlon based disciplines).
+ *   </li>
+ *   <li>
+ *     {@link #getT1() t1} : the first transition time.
+ *   </li>
+ *   <li>
+ *     {@link #getBike() bike} : the bike split time.
+ *   </li>
+ *   <li>
+ *     {@link #getT2() t2} : the second transition time.
+ *   </li>
+ *   <li>
+ *     {@link #getRun() run} : the run split time.
+ *   </li>
+ *   <li>
+ *     {@link #getSecondRun() secondRun} : the second run split time
+ *     (for duathlon and double-biathlon based disciplines).
+ *   </li>
+ *   <li>
+ *     {@link #getT3() t3} : the third transition time
+ *     (for double-biathlon based disciplines).
+ *   </li>
+ *   <li>
+ *     {@link #getSecondBike() secondBike} : the second bike split time
+ *     (for double-biathlon based disciplines).
+ *   </li>
+ *   <li>
+ *     {@link #getTotal() total} : the total race time.
+ *   </li>
+ *   <li>
+ *     {@link #getPoints() points} : the points earned by the athlete in this {@link Race}.
+ *   </li>
+ * </ul>
+ */
+@Entity(name = "IndividualResult")
+@Table(name = "individual_result")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator",
+    sequenceName = "seq_individual_result_id",
+    allocationSize = 1
+)
+public class IndividualResult extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "race_id", referencedColumnName = "id", nullable = false)
+  private Race race;
+
+  @Column(name = "rank")
+  private Integer rank;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "source_result_id", referencedColumnName = "id")
+  private IndividualResult sourceResult;
+
+  @Column(name = "penalty")
+  @Convert(converter = PenaltyConverter.class)
+  private Penalty penalty;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "athlete_id", referencedColumnName = "id", nullable = false)
+  private Athlete athlete;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "team_id", referencedColumnName = "id")
+  private Team team;
+
+  @Column(name = "team_name")
+  private String teamName;
+
+  @Convert(converter = AgeGroupConverter.class)
+  @Column(name = "age_group")
+  private AgeGroup ageGroup;
+
+  @Convert(converter = ParaClassConverter.class)
+  @Column(name = "para_class")
+  private ParaClass paraClass;
+
+  @Column(name = "bib")
+  private String bib;
+
+  @Column(name = "swim")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration swim;
+
+  @Column(name = "first_bike")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration firstBike;
+
+  @Column(name = "first_run")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration firstRun;
+
+  @Column(name = "t1")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration t1;
+
+  @Column(name = "bike")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration bike;
+
+  @Column(name = "t2")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration t2;
+
+  @Column(name = "run")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration run;
+
+  @Column(name = "second_run")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration secondRun;
+
+  @Column(name = "t3")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration t3;
+
+  @Column(name = "second_bike")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration secondBike;
+
+  @Column(name = "total")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration total;
+
+  @Column(name = "points")
+  private Integer points;
+
+  public IndividualResult() {
+    super();
+  }
+
+  public Race getRace() {
+    return race;
+  }
+
+  public void setRace(Race race) {
+    this.race = race;
+  }
+
+  public Integer getRank() {
+    return rank;
+  }
+
+  public void setRank(Integer rank) {
+    this.rank = rank;
+  }
+
+  public IndividualResult getSourceResult() {
+    return sourceResult;
+  }
+
+  public void setSourceResult(IndividualResult sourceResult) {
+    this.sourceResult = sourceResult;
+  }
+
+  public Penalty getPenalty() {
+    return penalty;
+  }
+
+  public void setPenalty(Penalty penalty) {
+    this.penalty = penalty;
+  }
+
+  public Athlete getAthlete() {
+    return athlete;
+  }
+
+  public void setAthlete(Athlete athlete) {
+    this.athlete = athlete;
+  }
+
+  public Team getTeam() {
+    return team;
+  }
+
+  public void setTeam(Team team) {
+    this.team = team;
+  }
+
+  public String getTeamName() {
+    return teamName;
+  }
+
+  public void setTeamName(String teamName) {
+    this.teamName = teamName;
+  }
+
+  public AgeGroup getAgeGroup() {
+    return ageGroup;
+  }
+
+  public void setAgeGroup(AgeGroup ageGroup) {
+    this.ageGroup = ageGroup;
+  }
+
+  public ParaClass getParaClass() {
+    return paraClass;
+  }
+
+  public void setParaClass(ParaClass paraClass) {
+    this.paraClass = paraClass;
+  }
+
+  public String getBib() {
+    return bib;
+  }
+
+  public void setBib(String bib) {
+    this.bib = bib;
+  }
+
+  public Duration getSwim() {
+    return swim;
+  }
+
+  public void setSwim(Duration swim) {
+    this.swim = swim;
+  }
+
+  public Duration getFirstBike() {
+    return firstBike;
+  }
+
+  public void setFirstBike(Duration firstBike) {
+    this.firstBike = firstBike;
+  }
+
+  public Duration getFirstRun() {
+    return firstRun;
+  }
+
+  public void setFirstRun(Duration firstRun) {
+    this.firstRun = firstRun;
+  }
+
+  public Duration getT1() {
+    return t1;
+  }
+
+  public void setT1(Duration t1) {
+    this.t1 = t1;
+  }
+
+  public Duration getBike() {
+    return bike;
+  }
+
+  public void setBike(Duration bike) {
+    this.bike = bike;
+  }
+
+  public Duration getT2() {
+    return t2;
+  }
+
+  public void setT2(Duration t2) {
+    this.t2 = t2;
+  }
+
+  public Duration getRun() {
+    return run;
+  }
+
+  public void setRun(Duration run) {
+    this.run = run;
+  }
+
+  public Duration getSecondRun() {
+    return secondRun;
+  }
+
+  public void setSecondRun(Duration secondRun) {
+    this.secondRun = secondRun;
+  }
+
+  public Duration getT3() {
+    return t3;
+  }
+
+  public void setT3(Duration t3) {
+    this.t3 = t3;
+  }
+
+  public Duration getSecondBike() {
+    return secondBike;
+  }
+
+  public void setSecondBike(Duration secondBike) {
+    this.secondBike = secondBike;
+  }
+
+  public Duration getTotal() {
+    return total;
+  }
+
+  public void setTotal(Duration total) {
+    this.total = total;
+  }
+
+  public Integer getPoints() {
+    return points;
+  }
+
+  public void setPoints(Integer points) {
+    this.points = points;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", IndividualResult.class.getSimpleName() + "[", "]")
+        .add("id=" + this.getId())
+        .add("raceId=" + Optional.ofNullable(race).map(Race::getId).orElse(null))
+        .add("rank=" + rank)
+        .add("sourceResultId=" + Optional.ofNullable(sourceResult)
+            .map(IndividualResult::getId)
+            .orElse(null))
+        .add("penalty=" + Optional.ofNullable(penalty).map(Penalty::getCode).orElse(null))
+        .add("athleteId=" + Optional.ofNullable(athlete).map(Athlete::getId).orElse(null))
+        .add("teamId=" + Optional.ofNullable(team).map(Team::getId).orElse(null))
+        .add("teamName='" + teamName + "'")
+        .add("ageGroup=" + Optional.ofNullable(ageGroup).map(AgeGroup::getCode).orElse(null))
+        .add("paraClass=" + Optional.ofNullable(paraClass).map(ParaClass::getCode).orElse(null))
+        .add("bib='" + bib + "'")
+        .add("swim=" + swim)
+        .add("firstBike=" + firstBike)
+        .add("firstRun=" + firstRun)
+        .add("t1=" + t1)
+        .add("bike=" + bike)
+        .add("t2=" + t2)
+        .add("run=" + run)
+        .add("secondRun=" + secondRun)
+        .add("t3=" + t3)
+        .add("secondBike=" + secondBike)
+        .add("total=" + total)
+        .add("points=" + points)
+        .toString();
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/Race.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/Race.java
@@ -20,13 +20,13 @@
 
 package com.endurancetrio.data.event.model.entity;
 
-import com.endurancetrio.data.common.model.entity.BaseEntity;
 import com.endurancetrio.data.event.model.converter.GenderCategoryConverter;
 import com.endurancetrio.data.event.model.converter.RaceStatusConverter;
 import com.endurancetrio.data.event.model.converter.RaceTypeConverter;
 import com.endurancetrio.data.event.model.enumerator.GenderCategory;
 import com.endurancetrio.data.event.model.enumerator.RaceStatus;
 import com.endurancetrio.data.event.model.enumerator.RaceType;
+import com.endurancetrio.data.common.model.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -37,7 +37,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
@@ -50,21 +49,6 @@ import java.util.Set;
 import java.util.StringJoiner;
 
 /**
- * The {@link Race} entity represents a contest within an {@link Event}.
- * <p>
- * A {@link Race} is uniquely defined by its {@link Course} and its start list formation rules,
- * meaning no two {@link Race races} can have identical {@link Course course} and start list
- * formation rules. Additionally, each {@link Race} corresponds to a single start; a {@link Race}
- * cannot have multiple starts.
- * <p>
- * Both individual and collective competitions are represented by this entity. Collective
- * competitions (such as club or team events) derive their classification from the results
- * of individual {@link Race races} which are its {@link #getParentRaces() parent races}.
- * <p>
- * In most cases, a {@link Race} belongs to a single {@link Course}. However, in specific
- * scenarios (e.g., collective youth races whose classification derives from multiple individual
- * {@link Race races}), a {@link Race} may belong to multiple {@link Course courses}.
- * <p>
  * The {@link Race}'s fields are defined as follows:
  * <ul>
  *   <li>
@@ -106,12 +90,9 @@ import java.util.StringJoiner;
  *     If the {@link #getGenderCategory() genderCategory} of the {@link Race} is sufficient to
  *     unequivocally distinguish the {@link #getGenderCategory() genderCategory}, only the
  *     {@link #getGenderCategory() genderCategory} is used as a {@link #getSubtitle() subtitle}
- *     (e.g., "Women"). If the {@link #getGenderCategory() genderCategory} is not sufficient
- *     to unequivocally identify the {@link Race}, the {@link #getAgeGroup() ageGroup} and
- *     the {@link #getGenderCategory() genderCategory} are used (e.g., "Elite Women").
+ *     (e.g., "Women").
  *   </li>
  *   <li>{@link #getGenderCategory() genderCategory} the gender category of the {@link Race}.</li>
- *   <li>{@link #getAgeGroup() ageGroup} : the {@link AgeGroup age group} of the {@link Race}.</li>
  *   <li>{@link #getDate() date} : the date of the {@link Race}.</li>
  *   <li>{@link #getTime() time} : the time scheduled for the starting gun of the {@link Race}.</li>
  *   <li>
@@ -130,7 +111,7 @@ import java.util.StringJoiner;
  *     {@link #getResultsFiles() resultsFiles} : the {@link ResultsFile} of the {@link Race}.
  *   </li>
  * </ul>
- */
+*/
 @Entity(name = "Race")
 @Table(name = "race")
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -172,9 +153,6 @@ public class Race extends BaseEntity<Long> {
   @Convert(converter = GenderCategoryConverter.class)
   private GenderCategory genderCategory;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "age_group_id", nullable = false)
-  private AgeGroup ageGroup;
 
   @Column(name = "race_date", nullable = false)
   LocalDate date;
@@ -320,14 +298,6 @@ public class Race extends BaseEntity<Long> {
     this.genderCategory = genderCategory;
   }
 
-  public AgeGroup getAgeGroup() {
-    return ageGroup;
-  }
-
-  public void setAgeGroup(AgeGroup ageGroup) {
-    this.ageGroup = ageGroup;
-  }
-
   public LocalDate getDate() {
     return date;
   }
@@ -395,7 +365,6 @@ public class Race extends BaseEntity<Long> {
         .add("title='" + title + "'")
         .add("subtitle='" + subtitle + "'")
         .add("genderCategory=" + genderCategory.getCode())
-        .add("ageGroup=" + ageGroup.getTitle())
         .add("date=" + date)
         .add("time=" + time)
         .add("raceStatus=" + raceStatus.getCode())

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/TeamResult.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/TeamResult.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.entity;
+
+import com.endurancetrio.data.common.model.entity.BaseEntity;
+import com.endurancetrio.data.competitor.model.converter.AgeGroupConverter;
+import com.endurancetrio.data.competitor.model.converter.ParaClassConverter;
+import com.endurancetrio.data.competitor.model.entity.Team;
+import com.endurancetrio.data.competitor.model.enumerator.AgeGroup;
+import com.endurancetrio.data.competitor.model.enumerator.ParaClass;
+import com.endurancetrio.data.event.model.converter.DurationToIntegerConverter;
+import com.endurancetrio.data.event.model.converter.PenaltyConverter;
+import com.endurancetrio.data.event.model.enumerator.Penalty;
+import com.endurancetrio.data.event.model.enumerator.RaceType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.io.Serial;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * The {@link TeamResult} entity represents a team's result in a collective {@link Race}.
+ * <p>
+ * Team results are calculated from the individual results of team members. The calculation method
+ * depends on the {@link RaceType race type}.
+ * <p>
+ * The {@link TeamResult}'s fields are defined as follows:
+ * <ul>
+ *   <li>
+ *     {@link #getId() id} : the unique identifier of the {@link TeamResult} that
+ *     is automatically generated and is the primary key.
+ *   </li>
+ *   <li>
+ *     {@link #getRace() race} : the {@link Race} that this team result belongs to.
+ *   </li>
+ *   <li>
+ *     {@link #getRank() rank} : the team's finishing position in the team classification.
+ *   </li>
+ *   <li>
+ *     {@link #getSourceResult() sourceResult} : the parent {@link TeamResult} that this
+ *     result is derived from, if any.
+ *   </li>
+ *   <li>
+ *     {@link #getPenalty() penalty} : the {@link Penalty} applied to the team in this
+ *     {@link Race}.
+ *   </li>
+ *   <li>
+ *     {@link #getTeam() team} : the {@link Team} that this result belongs to.
+ *   </li>
+ *   <li>
+ *     {@link #getTeamName() teamName} : the display name of the {@link Team} as it appears
+ *     in this specific {@link Race}'s results.
+ *   </li>
+ *   <li>
+ *     {@link #getAthletesCount() athletesCount} : the number of athletes contributing
+ *     to this team result.
+ *   </li>
+ *   <li>
+ *     {@link #getIndividualResults() individualResults} : the individual
+ *     {@link IndividualResult race results} that contribute to this team result.
+ *   </li>
+ *   <li>
+ *     {@link #getAgeGroup() ageGroup} : the {@link AgeGroup} of the team for this
+ *     specific {@link Race}.
+ *   </li>
+ *   <li>
+ *     {@link #getBib() bib} : the team's race bib number.
+ *   </li>
+ *   <li>
+ *     {@link #getCumulativeRank() cumulativeRank} : the sum of the finishing positions
+ *     of the athletes contributing to the team classification.
+ *   </li>
+ *   <li>
+ *     {@link #getTotal() total} : the total team time in milliseconds.
+ *   </li>
+ *   <li>
+ *     {@link #getPoints() points} : the points earned by the team in this {@link Race}.
+ *   </li>
+ * </ul>
+ */
+@Entity(name = "TeamResult")
+@Table(name = "team_result")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator", sequenceName = "seq_team_result_id", allocationSize = 1
+)
+public class TeamResult extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "race_id", referencedColumnName = "id", nullable = false)
+  private Race race;
+
+  @Column(name = "rank", nullable = false)
+  private Integer rank;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "source_result_id", referencedColumnName = "id")
+  private TeamResult sourceResult;
+
+  @Column(name = "penalty")
+  @Convert(converter = PenaltyConverter.class)
+  private Penalty penalty;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "team_id", referencedColumnName = "id", nullable = false)
+  private Team team;
+
+  @Column(name = "team_name", nullable = false)
+  private String teamName;
+
+  @Column(name = "athletes_count", nullable = false)
+  private Integer athletesCount;
+
+  @ManyToMany(fetch = FetchType.LAZY)
+  @JoinTable(
+      name = "team_result_individual_result",
+      joinColumns = @JoinColumn(name = "team_result_id"),
+      inverseJoinColumns = @JoinColumn(name = "individual_result_id")
+  )
+  private Set<IndividualResult> individualResults;
+
+  @Convert(converter = AgeGroupConverter.class)
+  @Column(name = "age_group")
+  private AgeGroup ageGroup;
+
+  @Convert(converter = ParaClassConverter.class)
+  @Column(name = "para_class")
+  private ParaClass paraClass;
+
+  @Column(name = "bib")
+  private String bib;
+
+  @Column(name = "cumulative_rank")
+  private Integer cumulativeRank;
+
+  @Column(name = "total")
+  @Convert(converter = DurationToIntegerConverter.class)
+  private Duration total;
+
+  @Column(name = "points")
+  private Integer points;
+
+  public TeamResult() {
+    super();
+    this.individualResults = new HashSet<>();
+  }
+
+  /**
+   * Adds an individual {@link IndividualResult} to this {@link TeamResult}'s contributing results.
+   *
+   * @param individualResult the {@link IndividualResult} to add; ignored if {@code null} or already
+   *                         present
+   */
+  public void addIndividualResult(IndividualResult individualResult) {
+    if (individualResult != null) {
+      this.individualResults.add(individualResult);
+    }
+  }
+
+  /**
+   * Removes an individual {@link IndividualResult} from this {@link TeamResult}'s contributing
+   * results.
+   *
+   * @param individualResult the {@link IndividualResult} to remove; ignored if {@code null} or not
+   *                         present
+   */
+  public void removeIndividualResult(IndividualResult individualResult) {
+    if (individualResult != null) {
+      this.individualResults.remove(individualResult);
+    }
+  }
+
+  public Race getRace() {
+    return race;
+  }
+
+  public void setRace(Race race) {
+    this.race = race;
+  }
+
+  public Integer getRank() {
+    return rank;
+  }
+
+  public void setRank(Integer rank) {
+    this.rank = rank;
+  }
+
+  public TeamResult getSourceResult() {
+    return sourceResult;
+  }
+
+  public void setSourceResult(TeamResult sourceResult) {
+    this.sourceResult = sourceResult;
+  }
+
+  public Penalty getPenalty() {
+    return penalty;
+  }
+
+  public void setPenalty(Penalty penalty) {
+    this.penalty = penalty;
+  }
+
+  public Team getTeam() {
+    return team;
+  }
+
+  public void setTeam(Team team) {
+    this.team = team;
+  }
+
+  public String getTeamName() {
+    return teamName;
+  }
+
+  public void setTeamName(String teamName) {
+    this.teamName = teamName;
+  }
+
+  public Integer getAthletesCount() {
+    return athletesCount;
+  }
+
+  public void setAthletesCount(Integer athletesCount) {
+    this.athletesCount = athletesCount;
+  }
+
+  public Set<IndividualResult> getIndividualResults() {
+    return individualResults;
+  }
+
+  public void setIndividualResults(Set<IndividualResult> individualResults) {
+    this.individualResults = individualResults;
+  }
+
+  public AgeGroup getAgeGroup() {
+    return ageGroup;
+  }
+
+  public void setAgeGroup(AgeGroup ageGroup) {
+    this.ageGroup = ageGroup;
+  }
+
+  public ParaClass getParaClass() {
+    return paraClass;
+  }
+
+  public void setParaClass(ParaClass paraClass) {
+    this.paraClass = paraClass;
+  }
+
+  public String getBib() {
+    return bib;
+  }
+
+  public void setBib(String bib) {
+    this.bib = bib;
+  }
+
+  public Integer getCumulativeRank() {
+    return cumulativeRank;
+  }
+
+  public void setCumulativeRank(Integer cumulativeRank) {
+    this.cumulativeRank = cumulativeRank;
+  }
+
+  public Duration getTotal() {
+    return total;
+  }
+
+  public void setTotal(Duration total) {
+    this.total = total;
+  }
+
+  public Integer getPoints() {
+    return points;
+  }
+
+  public void setPoints(Integer points) {
+    this.points = points;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", TeamResult.class.getSimpleName() + "[", "]")
+        .add("id=" + this.getId())
+        .add("raceId=" + Optional.ofNullable(race).map(Race::getId).orElse(null))
+        .add("rank=" + rank)
+        .add("sourceResultId=" + Optional.ofNullable(sourceResult)
+            .map(TeamResult::getId)
+            .orElse(null))
+        .add("penalty=" + Optional.ofNullable(penalty).map(Penalty::getCode).orElse(null))
+        .add("teamId=" + Optional.ofNullable(team).map(Team::getId).orElse(null))
+        .add("teamName='" + teamName + "'")
+        .add("athletesCount=" + athletesCount)
+        .add("individualResults=" + Optional.ofNullable(individualResults)
+            .map(r -> r.stream().map(IndividualResult::getId).toList())
+            .orElse(null))
+        .add("ageGroup=" + Optional.ofNullable(ageGroup).map(AgeGroup::getCode).orElse(null))
+        .add("paraClass=" + Optional.ofNullable(paraClass).map(ParaClass::getCode).orElse(null))
+        .add("bib='" + bib + "'")
+        .add("total=" + total)
+        .add("points=" + points)
+        .add("cumulativeRank=" + cumulativeRank)
+        .toString();
+  }
+}

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/TriathlonBasedRace.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/TriathlonBasedRace.java
@@ -114,7 +114,6 @@ public class TriathlonBasedRace extends Race implements Serializable {
         .add("title='" + super.getTitle() + "'")
         .add("subtitle='" + super.getSubtitle() + "'")
         .add("genderCategory=" + super.getGenderCategory().getCode())
-        .add("ageGroup=" + super.getAgeGroup().getTitle())
         .add("date=" + super.getDate())
         .add("time=" + super.getTime())
         .add("raceStatus=" + super.getRaceStatus().getCode())

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/GenderCategory.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/GenderCategory.java
@@ -51,4 +51,9 @@ public enum GenderCategory {
   public String getCode() {
     return code;
   }
+
+  @Override
+  public String toString() {
+    return code;
+  }
 }

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/Penalty.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/Penalty.java
@@ -20,32 +20,35 @@
 
 package com.endurancetrio.data.event.model.enumerator;
 
-import com.endurancetrio.data.event.model.entity.Race;
-
-/**
- * The {@link RaceStatus} enum represents the status of a {@link Race}
- * <p>
- * It includes the following constants:
- * <ul>
- *   <li>
- *     {@link #PLANNED} : used for the {@link Race races} that are planned but not yet
- *     (or were ever) completed.
- *   </li>
- *   <li>{@link #COMPLETED} : used for the {@link Race races} that were completed.</li>
- * </ul>
- */
-public enum RaceStatus {
-  PLANNED("PLANNED"),
-  COMPLETED("COMPLETED");
+public enum Penalty {
+  DNF("DNF", "Did Not Finish", "Não Completou"),
+  LAP("LAP", "Lapped", "Ultrapassado"),
+  NC("NC", "Not Classified", "Não Classificado"),
+  NE("NE", "Not Eligible", "Não Elegível"),
+  DSQ("DSQ", "Disqualified", "Desclassificado"),
+  DNS("DNS", "Did Not Start", "Não Partiu"),
+  EC("EC", "Error Correction", "Correção de Erro");
 
   private final String code;
+  private final String titleEN;
+  private final String titlePT;
 
-  RaceStatus(String code) {
+  Penalty(String code, String titleEN, String titlePT) {
     this.code = code;
+    this.titleEN = titleEN;
+    this.titlePT = titlePT;
   }
 
   public String getCode() {
     return code;
+  }
+
+  public String getTitleEN() {
+    return titleEN;
+  }
+
+  public String getTitlePT() {
+    return titlePT;
   }
 
   @Override

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/RaceType.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/RaceType.java
@@ -85,4 +85,9 @@ public enum RaceType {
   public String getCode() {
     return code;
   }
+
+  @Override
+  public String toString() {
+    return code;
+  }
 }

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/WetsuitRule.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/enumerator/WetsuitRule.java
@@ -60,4 +60,9 @@ public enum WetsuitRule {
   public String getCode() {
     return code;
   }
+
+  @Override
+  public String toString() {
+    return code;
+  }
 }

--- a/endurancetrio-data/src/main/resources/db/DATABASE.md
+++ b/endurancetrio-data/src/main/resources/db/DATABASE.md
@@ -166,4 +166,19 @@ timestamp-based naming convention.
 15. Fixes the course sport and title for biatlo events inserted in 1988 and 1989:
     - [V20260607.001__fix-1988-1989-biatlo-course-types-h2.sql](migration/dml/h2/V20260607.001__fix-1988-1989-biatlo-course-types-h2.sql)
     - [V20260607.001__fix-1988-1989-biatlo-course-types-postgres.sql](migration/dml/postgres/V20260607.001__fix-1988-1989-biatlo-course-types-postgres.sql)
+16. Swaps the course IDs for the course_race junction table:
+    - [V20260610.001__swap-course-ids-course-race-h2.sql](migration/dml/h2/V20260610.001__swap-course-ids-course-race-h2.sql)
+    - [V20260610.001__swap-course-ids-course-race-postgres.sql](migration/dml/postgres/V20260610.001__swap-course-ids-course-race-postgres.sql)
+17. Reverts the course type fixes for biatlo events inserted in 1988 and 1989:
+    - [V20260610.002__revert-1988-1989-biatlo-course-types-h2.sql](migration/dml/h2/V20260610.002__revert-1988-1989-biatlo-course-types-h2.sql)
+    - [V20260610.002__revert-1988-1989-biatlo-course-types-postgres.sql](migration/dml/postgres/V20260610.002__revert-1988-1989-biatlo-course-types-postgres.sql)
+18. Moves race 148 to course 37:
+    - [V20260610.003__move-race-148-to-course-37-h2.sql](migration/dml/h2/V20260610.003__move-race-148-to-course-37-h2.sql)
+    - [V20260610.003__move-race-148-to-course-37-postgres.sql](migration/dml/postgres/V20260610.003__move-race-148-to-course-37-postgres.sql)
+19. Fixes the event-organizer relationships:
+    - [V20260610.004__fix-event-organizers-h2.sql](migration/dml/h2/V20260610.004__fix-event-organizers-h2.sql)
+    - [V20260610.004__fix-event-organizers-postgres.sql](migration/dml/postgres/V20260610.004__fix-event-organizers-postgres.sql)
+20. Creates the result data model tables:
+    - [V20260620.001__create-result-data-model-h2.sql](migration/ddl/h2/V20260620.001__create-result-data-model-h2.sql)
+    - [V20260620.001__create-result-data-model-postgres.sql](migration/ddl/postgres/V20260620.001__create-result-data-model-postgres.sql)
 

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.000.001.001__create-tables-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.000.001.001__create-tables-h2.sql
@@ -22,14 +22,14 @@
 --
 
 -- Create the schema for the EnduranceTrio application
-CREATE SCHEMA IF NOT EXISTS endurancetrio_community;
+CREATE SCHEMA IF NOT EXISTS endurancetrio_hub;
 
 -- Create sequence for the event table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_event_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_event_id START WITH 1 INCREMENT BY 1;
 
 -- Create the event table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.event (
-  id                BIGINT      DEFAULT nextval('endurancetrio_community.seq_event_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.event (
+  id                BIGINT      DEFAULT nextval('endurancetrio_hub.seq_event_id') NOT NULL,
   event_reference   VARCHAR(14)  NOT NULL,
   title             VARCHAR(512) NOT NULL,
   start_date        DATE         NOT NULL,
@@ -42,11 +42,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.event (
 );
 
 -- Create sequence for the organizer table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_organizer_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_organizer_id START WITH 1 INCREMENT BY 1;
 
 -- Create the organizer table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.organizer (
-  id              BIGINT       DEFAULT nextval('endurancetrio_community.seq_organizer_id')  NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.organizer (
+  id              BIGINT       DEFAULT nextval('endurancetrio_hub.seq_organizer_id')  NOT NULL,
   name            VARCHAR(255) NOT NULL,
   district        VARCHAR(255) NOT NULL,
   county          VARCHAR(255) NOT NULL,
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.organizer (
 );
 
 -- Create the event_organizer table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.event_organizer (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.event_organizer (
   event_id      BIGINT NOT NULL,
   organizer_id  BIGINT NOT NULL,
   CONSTRAINT pk_event_organizer PRIMARY KEY (event_id, organizer_id),
@@ -67,11 +67,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.event_organizer (
 );
 
 -- Create sequence for the event_file table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_event_file_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_event_file_id START WITH 1 INCREMENT BY 1;
 
 -- Create the event_file table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.event_file (
-  id        BIGINT       DEFAULT nextval('endurancetrio_community.seq_event_file_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.event_file (
+  id        BIGINT       DEFAULT nextval('endurancetrio_hub.seq_event_file_id') NOT NULL,
   event_id  BIGINT       NOT NULL,
   title     VARCHAR(255) NOT NULL,
   file_type VARCHAR(32)  NOT NULL,
@@ -84,21 +84,21 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.event_file (
 );
 
 -- Create index on the event_file table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_event_file_event_id
-  ON endurancetrio_community.event_file (event_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_event_file_event_id
+  ON endurancetrio_hub.event_file (event_id);
 
 -- Create sequence for the distance table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_distance_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_distance_id START WITH 1 INCREMENT BY 1;
 
 -- Create the distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.distance (
-  id            BIGINT      DEFAULT nextval('endurancetrio_community.seq_distance_id')  NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.distance (
+  id            BIGINT      DEFAULT nextval('endurancetrio_hub.seq_distance_id')  NOT NULL,
   distance_type VARCHAR(32) NOT NULL,
   CONSTRAINT pk_distance PRIMARY KEY (id)
 );
 
 -- Create the aquabike_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.aquabike_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.aquabike_distance (
   id            BIGINT NOT NULL,
   swim_distance INTEGER,
   swim_laps     INTEGER,
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.aquabike_distance (
 );
 
 -- Create the aquathlon_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.aquathlon_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.aquathlon_distance (
   id            BIGINT NOT NULL,
   swim_distance INTEGER,
   swim_laps     INTEGER,
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.aquathlon_distance (
 );
 
 -- Create the biathlon_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.biathlon_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.biathlon_distance (
   id            BIGINT NOT NULL,
   bike_distance INTEGER,
   bike_laps     INTEGER,
@@ -131,7 +131,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.biathlon_distance (
 );
 
 -- Create the double_biathlon_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.double_biathlon_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.double_biathlon_distance (
   id                    BIGINT NOT NULL,
   first_bike_distance   INTEGER,
   first_bike_laps       INTEGER,
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.double_biathlon_distance (
 );
 
 -- Create the duathlon_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.duathlon_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.duathlon_distance (
   id                  BIGINT NOT NULL,
   first_run_distance  INTEGER,
   first_run_laps      INTEGER,
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.duathlon_distance (
 );
 
 -- Create the single_sport_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.single_sport_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.single_sport_distance (
   id       BIGINT NOT NULL,
   distance INTEGER,
   laps     INTEGER,
@@ -169,7 +169,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.single_sport_distance (
 );
 
 -- Create the triathlon_distance table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.triathlon_distance (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.triathlon_distance (
   id            BIGINT NOT NULL,
   swim_distance INTEGER,
   swim_laps     INTEGER,
@@ -182,11 +182,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.triathlon_distance (
 );
 
 -- Create sequence for the course table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_course_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_course_id START WITH 1 INCREMENT BY 1;
 
 -- Create the course table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.course (
-  id          BIGINT       DEFAULT nextval('endurancetrio_community.seq_course_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.course (
+  id          BIGINT       DEFAULT nextval('endurancetrio_hub.seq_course_id') NOT NULL,
   event_id    BIGINT       NOT NULL,
   title       VARCHAR(255) NOT NULL,
   sport       VARCHAR(32)  NOT NULL,
@@ -199,26 +199,26 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.course (
 );
 
 -- Create index on the course table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_course_event_id
-  ON endurancetrio_community.course(event_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_course_event_id
+  ON endurancetrio_hub.course(event_id);
 
 -- Create sequence for the age_group table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_age_group_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_age_group_id START WITH 1 INCREMENT BY 1;
 
 -- Create the age_group table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.age_group (
-  id          BIGINT       DEFAULT nextval('endurancetrio_community.seq_age_group_id')  NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.age_group (
+  id          BIGINT       DEFAULT nextval('endurancetrio_hub.seq_age_group_id')  NOT NULL,
   title       VARCHAR(255) NOT NULL,
   short_title VARCHAR(16)  NOT NULL,
   CONSTRAINT pk_age_group PRIMARY KEY (id)
 );
 
 -- Create sequence for the race table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_race_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_race_id START WITH 1 INCREMENT BY 1;
 
 -- Create the race table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.race (
-  id              BIGINT       DEFAULT nextval('endurancetrio_community.seq_race_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.race (
+  id              BIGINT       DEFAULT nextval('endurancetrio_hub.seq_race_id') NOT NULL,
   race_reference  VARCHAR(18)  NOT NULL,
   race_type       VARCHAR(32)  NOT NULL,
   title           VARCHAR(255) NOT NULL,
@@ -237,11 +237,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.race (
 );
 
 -- Create index on the race table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_race_age_group_id
-  ON endurancetrio_community.race(age_group_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_race_age_group_id
+  ON endurancetrio_hub.race(age_group_id);
 
 -- Create the course_race table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.course_race (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.course_race (
   course_id BIGINT NOT NULL,
   race_id   BIGINT NOT NULL,
   CONSTRAINT pk_course_race PRIMARY KEY (course_id, race_id),
@@ -252,7 +252,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.course_race (
 );
 
 -- Create the race_hierarchy table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.race_hierarchy (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.race_hierarchy (
   race_id        BIGINT NOT NULL,
   parent_race_id BIGINT NOT NULL,
   CONSTRAINT pk_race_hierarchy PRIMARY KEY (race_id, parent_race_id),
@@ -263,7 +263,7 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.race_hierarchy (
 );
 
 -- Create the triathlon_based_race table
-CREATE TABLE endurancetrio_community.triathlon_based_race (
+CREATE TABLE endurancetrio_hub.triathlon_based_race (
   id                BIGINT           NOT NULL,
   water_temperature DOUBLE PRECISION,
   wetsuit_rule      VARCHAR(32)      NOT NULL,
@@ -272,11 +272,11 @@ CREATE TABLE endurancetrio_community.triathlon_based_race (
 );
 
 -- Create sequence for the results_file table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_results_file_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_results_file_id START WITH 1 INCREMENT BY 1;
 
 -- Create the results_file table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.results_file (
-  id        BIGINT       DEFAULT nextval('endurancetrio_community.seq_results_file_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.results_file (
+  id        BIGINT       DEFAULT nextval('endurancetrio_hub.seq_results_file_id') NOT NULL,
   race_id   BIGINT       NOT NULL,
   title     VARCHAR(255) NOT NULL,
   subtitle  VARCHAR(255) NOT NULL,
@@ -289,11 +289,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.results_file (
 );
 
 -- Create index on the results_file table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_results_file_race_id
-  ON endurancetrio_community.results_file(race_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_results_file_race_id
+  ON endurancetrio_hub.results_file(race_id);
 
 -- Create the tracker_account table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.tracker_account (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.tracker_account (
   owner       VARCHAR(50)  NOT NULL,
   account_key VARCHAR(100) NOT NULL,
   enabled     BOOLEAN      NOT NULL,
@@ -305,12 +305,12 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.tracker_account (
 );
 
 -- Create sequence for tracking_data table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_tracking_data_id
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_tracking_data_id
   START WITH 1 INCREMENT BY 5;
 
 -- Create the tracking_data table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.tracking_data (
-  id          BIGINT           DEFAULT nextval('endurancetrio_community.seq_tracking_data_id')  NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.tracking_data (
+  id          BIGINT           DEFAULT nextval('endurancetrio_hub.seq_tracking_data_id')  NOT NULL,
   account     VARCHAR(50)      NOT NULL,
   device      VARCHAR(50)      NOT NULL,
   record_time TIMESTAMP        NOT NULL,
@@ -327,11 +327,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.tracking_data (
 );
 
 -- Create indexes on the tracking_data table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_tracking_data_device
-  ON endurancetrio_community.tracking_data(device);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_tracking_data_device_time
-  ON endurancetrio_community.tracking_data(device, record_time);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_tracking_data_account
-  ON endurancetrio_community.tracking_data(account);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_tracking_data_account_device
-  ON endurancetrio_community.tracking_data(account, device);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_tracking_data_device
+  ON endurancetrio_hub.tracking_data(device);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_tracking_data_device_time
+  ON endurancetrio_hub.tracking_data(device, record_time);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_tracking_data_account
+  ON endurancetrio_hub.tracking_data(account);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_tracking_data_account_device
+  ON endurancetrio_hub.tracking_data(account, device);

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.002.000.001__create-telemetry-management-table-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.002.000.001__create-telemetry-management-table-h2.sql
@@ -22,16 +22,16 @@
 --
 
 -- Drops tracking_data table and its sequence
-DROP TABLE IF EXISTS endurancetrio_community.tracking_data;
-DROP SEQUENCE IF EXISTS endurancetrio_community.seq_tracking_data_id;
+DROP TABLE IF EXISTS endurancetrio_hub.tracking_data;
+DROP SEQUENCE IF EXISTS endurancetrio_hub.seq_tracking_data_id;
 
 -- Create sequence for the device_telemetry table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_device_telemetry_id
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_device_telemetry_id
   START WITH 1 INCREMENT BY 5 CACHE 5;
 
 -- Create the device_telemetry table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.device_telemetry (
-  id          BIGINT            DEFAULT nextval('endurancetrio_community.seq_device_telemetry_id')  NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.device_telemetry (
+  id          BIGINT            DEFAULT nextval('endurancetrio_hub.seq_device_telemetry_id')  NOT NULL,
   account     VARCHAR(50)       NOT NULL,
   device      VARCHAR(50)       NOT NULL,
   record_time TIMESTAMP         NOT NULL,
@@ -43,15 +43,15 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.device_telemetry (
   updated_at  TIMESTAMP,
   CONSTRAINT pk_device_telemetry PRIMARY KEY (id),
   CONSTRAINT fk_device_telemetry_tracker_account_owner
-    FOREIGN KEY (account) REFERENCES endurancetrio_community.tracker_account(owner)
+    FOREIGN KEY (account) REFERENCES endurancetrio_hub.tracker_account(owner)
 );
 
 -- Create indexes on the device_telemetry table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_device_telemetry_device
-  ON endurancetrio_community.device_telemetry(device);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_device_telemetry_device_time
-  ON endurancetrio_community.device_telemetry(device, record_time);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_device_telemetry_account
-  ON endurancetrio_community.device_telemetry(account);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_device_telemetry_account_device
-  ON endurancetrio_community.device_telemetry(account, device);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_device_telemetry_device
+  ON endurancetrio_hub.device_telemetry(device);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_device_telemetry_device_time
+  ON endurancetrio_hub.device_telemetry(device, record_time);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_device_telemetry_account
+  ON endurancetrio_hub.device_telemetry(account);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_device_telemetry_account_device
+  ON endurancetrio_hub.device_telemetry(account, device);

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.002.000.003__create-route-tables-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.002.000.003__create-route-tables-h2.sql
@@ -22,11 +22,11 @@
 --
 
 -- Create sequence for the route table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_route_id START WITH 1 INCREMENT BY 5;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_route_id START WITH 1 INCREMENT BY 5;
 
 -- Create the route table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.route (
-  id          BIGINT      DEFAULT nextval('endurancetrio_community.seq_route_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.route (
+  id          BIGINT      DEFAULT nextval('endurancetrio_hub.seq_route_id') NOT NULL,
   reference   VARCHAR(50) NOT NULL,
   version     INTEGER     NOT NULL DEFAULT 0,
   created_at  TIMESTAMP   NOT NULL,
@@ -36,12 +36,12 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.route (
 );
 
 -- Create sequence for the route_segment table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_route_segment_id
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_route_segment_id
   START WITH 1 INCREMENT BY 5;
 
 -- Create the route_segment table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.route_segment (
-  id            BIGINT      DEFAULT nextval('endurancetrio_community.seq_route_segment_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.route_segment (
+  id            BIGINT      DEFAULT nextval('endurancetrio_hub.seq_route_segment_id') NOT NULL,
   route_id      BIGINT      NOT NULL,
   segment_order INTEGER     NOT NULL,
   start_device  VARCHAR(50) NOT NULL,
@@ -55,6 +55,6 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.route_segment (
 
 -- Create indexes on the route_segment table
 CREATE INDEX IF NOT EXISTS idx_route_segment_route_id
-  ON endurancetrio_community.route_segment(route_id);
+  ON endurancetrio_hub.route_segment(route_id);
 CREATE INDEX IF NOT EXISTS idx_route_segment_route_id_segment_order
-  ON endurancetrio_community.route_segment(route_id, segment_order);
+  ON endurancetrio_hub.route_segment(route_id, segment_order);

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.004.000.001__add-auditable-columns-to-event-tables-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.004.000.001__add-auditable-columns-to-event-tables-h2.sql
@@ -21,7 +21,7 @@
 -- Description: Adds auditable columns to the EnduranceTrio application event domain tables
 --
 
-SET SCHEMA endurancetrio_community;
+SET SCHEMA endurancetrio_hub;
 
 ALTER TABLE event ADD COLUMN version    INTEGER   NOT NULL DEFAULT 0;
 ALTER TABLE event ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.004.000.002__remove-created-at-default-from-event-tables-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V000.004.000.002__remove-created-at-default-from-event-tables-h2.sql
@@ -21,7 +21,7 @@
 -- Description: Removes the DEFAULT CURRENT_TIMESTAMP from created_at on event domain tables
 --
 
-SET SCHEMA endurancetrio_community;
+SET SCHEMA endurancetrio_hub;
 
 ALTER TABLE event                    ALTER COLUMN created_at DROP DEFAULT;
 ALTER TABLE organizer                ALTER COLUMN created_at DROP DEFAULT;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V20260620.001__create-result-data-model-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V20260620.001__create-result-data-model-h2.sql
@@ -1,0 +1,201 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
+-- Description: Creates the athlete, team, para_class, individual_result, team_result and
+--   team_result_individual_result tables
+
+SET SCHEMA endurancetrio_community;
+
+-- Drop the age_group_id column from the race table
+ALTER TABLE endurancetrio_community.race DROP CONSTRAINT IF EXISTS fk_race_age_group_id;
+ALTER TABLE endurancetrio_community.race DROP COLUMN IF EXISTS age_group_id;
+
+-- Drop the old age_group table and recreate it with the new schema
+DROP TABLE IF EXISTS endurancetrio_community.age_group;
+
+-- Recreate the sequence (DROP TABLE above dropped it via OWNED BY)
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_age_group_id START WITH 1 INCREMENT BY 1;
+
+-- Create the age_group table with the new schema
+CREATE TABLE IF NOT EXISTS endurancetrio_community.age_group (
+  id              BIGINT       DEFAULT nextval('endurancetrio_community.seq_age_group_id') NOT NULL,
+  code            VARCHAR(50)  NOT NULL,
+  denomination_en VARCHAR(255) NOT NULL,
+  denomination_pt VARCHAR(255) NOT NULL,
+  version         INTEGER      NOT NULL DEFAULT 0,
+  created_at      TIMESTAMP    NOT NULL,
+  updated_at      TIMESTAMP,
+  CONSTRAINT pk_age_group PRIMARY KEY (id)
+);
+
+-- Create sequence for the para_class table primary key
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_para_class_id START WITH 1 INCREMENT BY 1;
+
+-- Create the para_class table
+CREATE TABLE IF NOT EXISTS endurancetrio_community.para_class (
+  id              BIGINT       DEFAULT nextval('endurancetrio_community.seq_para_class_id') NOT NULL,
+  code            VARCHAR(50)  NOT NULL,
+  denomination_en VARCHAR(255) NOT NULL,
+  denomination_pt VARCHAR(255) NOT NULL,
+  version         INTEGER      NOT NULL DEFAULT 0,
+  created_at      TIMESTAMP    NOT NULL,
+  updated_at      TIMESTAMP,
+  CONSTRAINT pk_para_class PRIMARY KEY (id)
+  );
+
+-- Create sequence for the athlete table primary key
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_athlete_id START WITH 1 INCREMENT BY 1;
+
+-- Create the athlete table
+CREATE TABLE IF NOT EXISTS endurancetrio_community.athlete (
+  id            BIGINT       DEFAULT nextval('endurancetrio_community.seq_athlete_id') NOT NULL,
+  full_name     VARCHAR(255) NOT NULL,
+  known_name    VARCHAR(255),
+  gender        VARCHAR(50),
+  country       VARCHAR(50),
+  year_of_birth INTEGER,
+  version       INTEGER      NOT NULL DEFAULT 0,
+  created_at    TIMESTAMP    NOT NULL,
+  updated_at    TIMESTAMP,
+  CONSTRAINT pk_athlete PRIMARY KEY (id)
+);
+
+-- Create sequence for the team table primary key
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_team_id START WITH 1 INCREMENT BY 1;
+
+-- Create the team table
+CREATE TABLE IF NOT EXISTS endurancetrio_community.team (
+  id         BIGINT       DEFAULT nextval('endurancetrio_community.seq_team_id') NOT NULL,
+  full_name  VARCHAR(255) NOT NULL,
+  short_name VARCHAR(255),
+  city       VARCHAR(255),
+  county     VARCHAR(255),
+  district   VARCHAR(255),
+  version    INTEGER      NOT NULL DEFAULT 0,
+  created_at TIMESTAMP    NOT NULL,
+  updated_at TIMESTAMP,
+  CONSTRAINT pk_team PRIMARY KEY (id)
+);
+
+-- Create sequence for the individual_result table primary key
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_individual_result_id START WITH 1 INCREMENT BY 1;
+
+-- Create the individual_result table
+CREATE TABLE IF NOT EXISTS endurancetrio_community.individual_result (
+  id               BIGINT       DEFAULT nextval('endurancetrio_community.seq_individual_result_id') NOT NULL,
+  race_id          BIGINT       NOT NULL,
+  rank             INTEGER,
+  source_result_id BIGINT,
+  penalty          VARCHAR(50),
+  athlete_id       BIGINT       NOT NULL,
+  team_id          BIGINT,
+  team_name        VARCHAR(255),
+  age_group        VARCHAR(32),
+  para_class       VARCHAR(32),
+  bib              VARCHAR(32),
+  swim             INTEGER,
+  first_bike       INTEGER,
+  first_run        INTEGER,
+  t1               INTEGER,
+  bike             INTEGER,
+  t2               INTEGER,
+  second_bike      INTEGER,
+  run              INTEGER,
+  t3               INTEGER,
+  second_run       INTEGER,
+  total            INTEGER,
+  points           INTEGER,
+  version          INTEGER      NOT NULL DEFAULT 0,
+  created_at       TIMESTAMP    NOT NULL,
+  updated_at       TIMESTAMP,
+  CONSTRAINT pk_individual_result PRIMARY KEY (id),
+  CONSTRAINT fk_individual_result_race_id
+    FOREIGN KEY (race_id) REFERENCES endurancetrio_community.race(id) ON DELETE CASCADE,
+  CONSTRAINT fk_individual_result_individual_result_id
+    FOREIGN KEY (source_result_id) REFERENCES endurancetrio_community.individual_result(id),
+  CONSTRAINT fk_individual_result_athlete_id
+    FOREIGN KEY (athlete_id) REFERENCES endurancetrio_community.athlete(id) ON DELETE CASCADE,
+  CONSTRAINT fk_individual_result_team_id
+    FOREIGN KEY (team_id) REFERENCES endurancetrio_community.team(id) ON DELETE CASCADE
+);
+
+-- Create indexes on the individual_result table
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_race_id
+  ON endurancetrio_community.individual_result (race_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_athlete_id
+  ON endurancetrio_community.individual_result (athlete_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_source_result_id
+  ON endurancetrio_community.individual_result (source_result_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_team_id
+  ON endurancetrio_community.individual_result (team_id);
+
+-- Create sequence for the team_result table primary key
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_team_result_id START WITH 1 INCREMENT BY 1;
+
+-- Create the team_result table
+CREATE TABLE IF NOT EXISTS endurancetrio_community.team_result (
+  id               BIGINT       DEFAULT nextval('endurancetrio_community.seq_team_result_id') NOT NULL,
+  race_id          BIGINT       NOT NULL,
+  rank             INTEGER      NOT NULL,
+  source_result_id BIGINT,
+  penalty          VARCHAR(50),
+  team_id          BIGINT       NOT NULL,
+  team_name        VARCHAR(255) NOT NULL,
+  athletes_count   INTEGER      NOT NULL,
+  age_group        VARCHAR(32),
+  para_class       VARCHAR(32),
+  bib              VARCHAR(32),
+  total            INTEGER,
+  points           INTEGER,
+  cumulative_rank  INTEGER,
+  version          INTEGER      NOT NULL DEFAULT 0,
+  created_at       TIMESTAMP    NOT NULL,
+  updated_at       TIMESTAMP,
+  CONSTRAINT pk_team_result PRIMARY KEY (id),
+  CONSTRAINT fk_team_result_race_id
+    FOREIGN KEY (race_id) REFERENCES endurancetrio_community.race(id) ON DELETE CASCADE,
+  CONSTRAINT fk_team_result_team_result_id
+    FOREIGN KEY (source_result_id) REFERENCES endurancetrio_community.team_result(id),
+  CONSTRAINT fk_team_result_team_id
+    FOREIGN KEY (team_id) REFERENCES endurancetrio_community.team(id)
+);
+
+-- Create indexes on the team_result table
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_race_id
+  ON endurancetrio_community.team_result (race_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_team_id
+  ON endurancetrio_community.team_result (team_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_source_result_id
+  ON endurancetrio_community.team_result (source_result_id);
+
+-- Create the team_result_individual_result table
+CREATE TABLE IF NOT EXISTS endurancetrio_community.team_result_individual_result (
+  team_result_id       BIGINT NOT NULL,
+  individual_result_id BIGINT NOT NULL,
+  CONSTRAINT pk_team_result_individual_result PRIMARY KEY (team_result_id, individual_result_id),
+  CONSTRAINT fk_team_result_individual_result_team_result_id
+    FOREIGN KEY (team_result_id) REFERENCES endurancetrio_community.team_result(id) ON DELETE CASCADE,
+  CONSTRAINT fk_team_result_individual_result_individual_result_id
+    FOREIGN KEY (individual_result_id) REFERENCES endurancetrio_community.individual_result(id) ON DELETE CASCADE
+);
+
+-- Create indexes on the team_result_individual_result table
+CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_individual_result_individual_result_id
+  ON endurancetrio_community.team_result_individual_result (individual_result_id);

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V20260620.001__create-result-data-model-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/h2/V20260620.001__create-result-data-model-h2.sql
@@ -21,21 +21,21 @@
 -- Description: Creates the athlete, team, para_class, individual_result, team_result and
 --   team_result_individual_result tables
 
-SET SCHEMA endurancetrio_community;
+SET SCHEMA endurancetrio_hub;
 
 -- Drop the age_group_id column from the race table
-ALTER TABLE endurancetrio_community.race DROP CONSTRAINT IF EXISTS fk_race_age_group_id;
-ALTER TABLE endurancetrio_community.race DROP COLUMN IF EXISTS age_group_id;
+ALTER TABLE endurancetrio_hub.race DROP CONSTRAINT IF EXISTS fk_race_age_group_id;
+ALTER TABLE endurancetrio_hub.race DROP COLUMN IF EXISTS age_group_id;
 
 -- Drop the old age_group table and recreate it with the new schema
-DROP TABLE IF EXISTS endurancetrio_community.age_group;
+DROP TABLE IF EXISTS endurancetrio_hub.age_group;
 
 -- Recreate the sequence (DROP TABLE above dropped it via OWNED BY)
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_age_group_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_age_group_id START WITH 1 INCREMENT BY 1;
 
 -- Create the age_group table with the new schema
-CREATE TABLE IF NOT EXISTS endurancetrio_community.age_group (
-  id              BIGINT       DEFAULT nextval('endurancetrio_community.seq_age_group_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.age_group (
+  id              BIGINT       DEFAULT nextval('endurancetrio_hub.seq_age_group_id') NOT NULL,
   code            VARCHAR(50)  NOT NULL,
   denomination_en VARCHAR(255) NOT NULL,
   denomination_pt VARCHAR(255) NOT NULL,
@@ -46,11 +46,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.age_group (
 );
 
 -- Create sequence for the para_class table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_para_class_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_para_class_id START WITH 1 INCREMENT BY 1;
 
 -- Create the para_class table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.para_class (
-  id              BIGINT       DEFAULT nextval('endurancetrio_community.seq_para_class_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.para_class (
+  id              BIGINT       DEFAULT nextval('endurancetrio_hub.seq_para_class_id') NOT NULL,
   code            VARCHAR(50)  NOT NULL,
   denomination_en VARCHAR(255) NOT NULL,
   denomination_pt VARCHAR(255) NOT NULL,
@@ -61,11 +61,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.para_class (
   );
 
 -- Create sequence for the athlete table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_athlete_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_athlete_id START WITH 1 INCREMENT BY 1;
 
 -- Create the athlete table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.athlete (
-  id            BIGINT       DEFAULT nextval('endurancetrio_community.seq_athlete_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.athlete (
+  id            BIGINT       DEFAULT nextval('endurancetrio_hub.seq_athlete_id') NOT NULL,
   full_name     VARCHAR(255) NOT NULL,
   known_name    VARCHAR(255),
   gender        VARCHAR(50),
@@ -78,11 +78,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.athlete (
 );
 
 -- Create sequence for the team table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_team_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_team_id START WITH 1 INCREMENT BY 1;
 
 -- Create the team table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.team (
-  id         BIGINT       DEFAULT nextval('endurancetrio_community.seq_team_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.team (
+  id         BIGINT       DEFAULT nextval('endurancetrio_hub.seq_team_id') NOT NULL,
   full_name  VARCHAR(255) NOT NULL,
   short_name VARCHAR(255),
   city       VARCHAR(255),
@@ -95,11 +95,11 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.team (
 );
 
 -- Create sequence for the individual_result table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_individual_result_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_individual_result_id START WITH 1 INCREMENT BY 1;
 
 -- Create the individual_result table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.individual_result (
-  id               BIGINT       DEFAULT nextval('endurancetrio_community.seq_individual_result_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.individual_result (
+  id               BIGINT       DEFAULT nextval('endurancetrio_hub.seq_individual_result_id') NOT NULL,
   race_id          BIGINT       NOT NULL,
   rank             INTEGER,
   source_result_id BIGINT,
@@ -127,31 +127,31 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.individual_result (
   updated_at       TIMESTAMP,
   CONSTRAINT pk_individual_result PRIMARY KEY (id),
   CONSTRAINT fk_individual_result_race_id
-    FOREIGN KEY (race_id) REFERENCES endurancetrio_community.race(id) ON DELETE CASCADE,
+    FOREIGN KEY (race_id) REFERENCES endurancetrio_hub.race(id) ON DELETE CASCADE,
   CONSTRAINT fk_individual_result_individual_result_id
-    FOREIGN KEY (source_result_id) REFERENCES endurancetrio_community.individual_result(id),
+    FOREIGN KEY (source_result_id) REFERENCES endurancetrio_hub.individual_result(id),
   CONSTRAINT fk_individual_result_athlete_id
-    FOREIGN KEY (athlete_id) REFERENCES endurancetrio_community.athlete(id) ON DELETE CASCADE,
+    FOREIGN KEY (athlete_id) REFERENCES endurancetrio_hub.athlete(id) ON DELETE CASCADE,
   CONSTRAINT fk_individual_result_team_id
-    FOREIGN KEY (team_id) REFERENCES endurancetrio_community.team(id) ON DELETE CASCADE
+    FOREIGN KEY (team_id) REFERENCES endurancetrio_hub.team(id) ON DELETE CASCADE
 );
 
 -- Create indexes on the individual_result table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_race_id
-  ON endurancetrio_community.individual_result (race_id);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_athlete_id
-  ON endurancetrio_community.individual_result (athlete_id);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_source_result_id
-  ON endurancetrio_community.individual_result (source_result_id);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_individual_result_team_id
-  ON endurancetrio_community.individual_result (team_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_individual_result_race_id
+  ON endurancetrio_hub.individual_result (race_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_individual_result_athlete_id
+  ON endurancetrio_hub.individual_result (athlete_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_individual_result_source_result_id
+  ON endurancetrio_hub.individual_result (source_result_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_individual_result_team_id
+  ON endurancetrio_hub.individual_result (team_id);
 
 -- Create sequence for the team_result table primary key
-CREATE SEQUENCE IF NOT EXISTS endurancetrio_community.seq_team_result_id START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS endurancetrio_hub.seq_team_result_id START WITH 1 INCREMENT BY 1;
 
 -- Create the team_result table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.team_result (
-  id               BIGINT       DEFAULT nextval('endurancetrio_community.seq_team_result_id') NOT NULL,
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.team_result (
+  id               BIGINT       DEFAULT nextval('endurancetrio_hub.seq_team_result_id') NOT NULL,
   race_id          BIGINT       NOT NULL,
   rank             INTEGER      NOT NULL,
   source_result_id BIGINT,
@@ -170,32 +170,32 @@ CREATE TABLE IF NOT EXISTS endurancetrio_community.team_result (
   updated_at       TIMESTAMP,
   CONSTRAINT pk_team_result PRIMARY KEY (id),
   CONSTRAINT fk_team_result_race_id
-    FOREIGN KEY (race_id) REFERENCES endurancetrio_community.race(id) ON DELETE CASCADE,
+    FOREIGN KEY (race_id) REFERENCES endurancetrio_hub.race(id) ON DELETE CASCADE,
   CONSTRAINT fk_team_result_team_result_id
-    FOREIGN KEY (source_result_id) REFERENCES endurancetrio_community.team_result(id),
+    FOREIGN KEY (source_result_id) REFERENCES endurancetrio_hub.team_result(id),
   CONSTRAINT fk_team_result_team_id
-    FOREIGN KEY (team_id) REFERENCES endurancetrio_community.team(id)
+    FOREIGN KEY (team_id) REFERENCES endurancetrio_hub.team(id)
 );
 
 -- Create indexes on the team_result table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_race_id
-  ON endurancetrio_community.team_result (race_id);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_team_id
-  ON endurancetrio_community.team_result (team_id);
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_source_result_id
-  ON endurancetrio_community.team_result (source_result_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_team_result_race_id
+  ON endurancetrio_hub.team_result (race_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_team_result_team_id
+  ON endurancetrio_hub.team_result (team_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_team_result_source_result_id
+  ON endurancetrio_hub.team_result (source_result_id);
 
 -- Create the team_result_individual_result table
-CREATE TABLE IF NOT EXISTS endurancetrio_community.team_result_individual_result (
+CREATE TABLE IF NOT EXISTS endurancetrio_hub.team_result_individual_result (
   team_result_id       BIGINT NOT NULL,
   individual_result_id BIGINT NOT NULL,
   CONSTRAINT pk_team_result_individual_result PRIMARY KEY (team_result_id, individual_result_id),
   CONSTRAINT fk_team_result_individual_result_team_result_id
-    FOREIGN KEY (team_result_id) REFERENCES endurancetrio_community.team_result(id) ON DELETE CASCADE,
+    FOREIGN KEY (team_result_id) REFERENCES endurancetrio_hub.team_result(id) ON DELETE CASCADE,
   CONSTRAINT fk_team_result_individual_result_individual_result_id
-    FOREIGN KEY (individual_result_id) REFERENCES endurancetrio_community.individual_result(id) ON DELETE CASCADE
+    FOREIGN KEY (individual_result_id) REFERENCES endurancetrio_hub.individual_result(id) ON DELETE CASCADE
 );
 
 -- Create indexes on the team_result_individual_result table
-CREATE INDEX IF NOT EXISTS endurancetrio_community.idx_team_result_individual_result_individual_result_id
-  ON endurancetrio_community.team_result_individual_result (individual_result_id);
+CREATE INDEX IF NOT EXISTS endurancetrio_hub.idx_team_result_individual_result_individual_result_id
+  ON endurancetrio_hub.team_result_individual_result (individual_result_id);

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.000.001.001__create-tables-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.000.001.001__create-tables-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Creates the tables for the EnduranceTrio application
 --
 
--- The schema `endurancetrio_community` must exist before running this script
-SET search_path TO endurancetrio_community;
+-- The schema `endurancetrio_hub` must exist before running this script
+SET search_path TO endurancetrio_hub;
 
 -- Create sequence for the event table primary key
 CREATE SEQUENCE IF NOT EXISTS seq_event_id START WITH 1 INCREMENT BY 1 CACHE 1;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.002.000.001__create-telemetry-management-table-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.002.000.001__create-telemetry-management-table-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Creates the EnduranceTrio application telemetry management database table
 --
 
--- The schema `endurancetrio_community` must exist before running this script
-SET search_path TO endurancetrio_community;
+-- The schema `endurancetrio_hub` must exist before running this script
+SET search_path TO endurancetrio_hub;
 
 -- Drops tracking_data table and its sequence
 DROP TABLE IF EXISTS tracking_data;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.002.000.003__create-route-tables-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.002.000.003__create-route-tables-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Creates the EnduranceTrio application route database tables
 --
 
--- The schema `endurancetrio_community` must exist before running this script
-SET search_path TO endurancetrio_community;
+-- The schema `endurancetrio_hub` must exist before running this script
+SET search_path TO endurancetrio_hub;
 
 -- Create sequence for the route table primary key
 CREATE SEQUENCE IF NOT EXISTS seq_route_id START WITH 1 INCREMENT BY 5 CACHE 5;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.004.000.001__add-auditable-columns-to-event-tables-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.004.000.001__add-auditable-columns-to-event-tables-postgres.sql
@@ -21,7 +21,7 @@
 -- Description: Adds auditable columns to the EnduranceTrio application event domain tables
 --
 
-SET search_path TO endurancetrio_community;
+SET search_path TO endurancetrio_hub;
 
 ALTER TABLE event ADD COLUMN version    INTEGER   NOT NULL DEFAULT 0;
 ALTER TABLE event ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.004.000.002__remove-created-at-default-from-event-tables-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V000.004.000.002__remove-created-at-default-from-event-tables-postgres.sql
@@ -21,7 +21,7 @@
 -- Description: Removes the DEFAULT CURRENT_TIMESTAMP from created_at on event domain tables
 --
 
-SET search_path TO endurancetrio_community;
+SET search_path TO endurancetrio_hub;
 
 ALTER TABLE event                    ALTER COLUMN created_at DROP DEFAULT;
 ALTER TABLE organizer                ALTER COLUMN created_at DROP DEFAULT;

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V20260620.001__create-result-data-model-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V20260620.001__create-result-data-model-postgres.sql
@@ -1,0 +1,212 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
+-- Description: Creates the athlete, team, para_class, individual_result, team_result,
+--   and team_result_individual_result tables
+
+SET search_path TO endurancetrio_community;
+
+-- Drop the age_group_id column from the race table
+DROP INDEX IF EXISTS idx_race_age_group_id;
+ALTER TABLE race DROP CONSTRAINT IF EXISTS fk_race_age_group_id;
+ALTER TABLE race DROP COLUMN IF EXISTS age_group_id;
+
+-- Drop the old age_group table and recreate it with the new schema
+DROP TABLE IF EXISTS age_group;
+
+-- Recreate the sequence (DROP TABLE above dropped it via OWNED BY)
+CREATE SEQUENCE IF NOT EXISTS seq_age_group_id START WITH 1 INCREMENT BY 1 CACHE 1;
+
+-- Create the age_group table with the new schema
+CREATE TABLE IF NOT EXISTS age_group (
+  id              BIGINT    DEFAULT nextval('seq_age_group_id') NOT NULL,
+  code            TEXT      NOT NULL,
+  denomination_en TEXT      NOT NULL,
+  denomination_pt TEXT      NOT NULL,
+  version         INTEGER   NOT NULL DEFAULT 0,
+  created_at      TIMESTAMP NOT NULL,
+  updated_at      TIMESTAMP,
+  CONSTRAINT pk_age_group PRIMARY KEY (id)
+);
+
+-- Create a dependency between the seq_age_group_id sequence and the age_group table primary key
+ALTER SEQUENCE IF EXISTS seq_age_group_id OWNED BY age_group.id;
+
+-- Create sequence for the para_class table primary key
+CREATE SEQUENCE IF NOT EXISTS seq_para_class_id START WITH 1 INCREMENT BY 1 CACHE 1;
+
+-- Create the para_class table
+CREATE TABLE IF NOT EXISTS para_class (
+  id              BIGINT    DEFAULT nextval('seq_para_class_id') NOT NULL,
+  code            TEXT      NOT NULL,
+  denomination_en TEXT      NOT NULL,
+  denomination_pt TEXT      NOT NULL,
+  version         INTEGER   NOT NULL DEFAULT 0,
+  created_at      TIMESTAMP NOT NULL,
+  updated_at      TIMESTAMP,
+  CONSTRAINT pk_para_class PRIMARY KEY (id)
+  );
+
+-- Create a dependency between the seq_para_class_id sequence and the para_class table primary key
+ALTER SEQUENCE IF EXISTS seq_para_class_id OWNED BY para_class.id;
+
+-- Create sequence for the athlete table primary key
+CREATE SEQUENCE IF NOT EXISTS seq_athlete_id START WITH 1 INCREMENT BY 1 CACHE 1;
+
+-- Create the athlete table
+CREATE TABLE IF NOT EXISTS athlete (
+  id            BIGINT    DEFAULT nextval('seq_athlete_id') NOT NULL,
+  full_name     TEXT      NOT NULL,
+  known_name    TEXT,
+  gender        TEXT,
+  country       TEXT,
+  year_of_birth INTEGER,
+  version       INTEGER   NOT NULL DEFAULT 0,
+  created_at    TIMESTAMP NOT NULL,
+  updated_at    TIMESTAMP,
+  CONSTRAINT pk_athlete PRIMARY KEY (id)
+);
+
+-- Create a dependency between the seq_athlete_id sequence and the athlete table primary key
+ALTER SEQUENCE IF EXISTS seq_athlete_id OWNED BY athlete.id;
+
+-- Create sequence for the team table primary key
+CREATE SEQUENCE IF NOT EXISTS seq_team_id START WITH 1 INCREMENT BY 1 CACHE 1;
+
+-- Create the team table
+CREATE TABLE IF NOT EXISTS team (
+  id         BIGINT    DEFAULT nextval('seq_team_id') NOT NULL,
+  full_name  TEXT      NOT NULL,
+  short_name TEXT,
+  city       TEXT,
+  county     TEXT,
+  district   TEXT,
+  version    INTEGER   NOT NULL DEFAULT 0,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP,
+  CONSTRAINT pk_team PRIMARY KEY (id)
+);
+
+-- Create a dependency between the seq_team_id sequence and the team table primary key
+ALTER SEQUENCE IF EXISTS seq_team_id OWNED BY team.id;
+
+-- Create sequence for the individual_result table primary key
+CREATE SEQUENCE IF NOT EXISTS seq_individual_result_id START WITH 1 INCREMENT BY 1 CACHE 1;
+
+-- Create the individual_result table
+CREATE TABLE IF NOT EXISTS individual_result (
+  id               BIGINT    DEFAULT nextval('seq_individual_result_id') NOT NULL,
+  race_id          BIGINT    NOT NULL,
+  rank             INTEGER,
+  source_result_id BIGINT,
+  penalty          TEXT,
+  athlete_id       BIGINT    NOT NULL,
+  team_id          BIGINT,
+  team_name        TEXT,
+  age_group        TEXT,
+  para_class       TEXT,
+  bib              TEXT,
+  swim             INTEGER,
+  first_bike       INTEGER,
+  first_run        INTEGER,
+  t1               INTEGER,
+  bike             INTEGER,
+  t2               INTEGER,
+  second_bike      INTEGER,
+  run              INTEGER,
+  t3               INTEGER,
+  second_run       INTEGER,
+  total            INTEGER,
+  points           INTEGER,
+  version          INTEGER   NOT NULL DEFAULT 0,
+  created_at       TIMESTAMP NOT NULL,
+  updated_at       TIMESTAMP,
+  CONSTRAINT pk_individual_result PRIMARY KEY (id),
+  CONSTRAINT fk_individual_result_race_id
+    FOREIGN KEY (race_id) REFERENCES race(id) ON DELETE CASCADE,
+  CONSTRAINT fk_individual_result_individual_result_id
+    FOREIGN KEY (source_result_id) REFERENCES individual_result(id),
+  CONSTRAINT fk_individual_result_athlete_id
+    FOREIGN KEY (athlete_id) REFERENCES athlete(id) ON DELETE CASCADE,
+  CONSTRAINT fk_individual_result_team_id
+    FOREIGN KEY (team_id) REFERENCES team(id) ON DELETE CASCADE
+);
+
+-- Create a dependency between the seq_individual_result_id sequence and the individual_result table primary key
+ALTER SEQUENCE IF EXISTS seq_individual_result_id OWNED BY individual_result.id;
+
+-- Create indexes on the individual_result table
+CREATE INDEX IF NOT EXISTS idx_individual_result_race_id ON individual_result (race_id);
+CREATE INDEX IF NOT EXISTS idx_individual_result_athlete_id ON individual_result (athlete_id);
+CREATE INDEX IF NOT EXISTS idx_individual_result_source_result_id ON individual_result (source_result_id);
+CREATE INDEX IF NOT EXISTS idx_individual_result_team_id ON individual_result (team_id);
+
+-- Create sequence for the team_result table primary key
+CREATE SEQUENCE IF NOT EXISTS seq_team_result_id START WITH 1 INCREMENT BY 1 CACHE 1;
+
+-- Create the team_result table
+CREATE TABLE IF NOT EXISTS team_result (
+  id               BIGINT    DEFAULT nextval('seq_team_result_id') NOT NULL,
+  race_id          BIGINT    NOT NULL,
+  rank             INTEGER   NOT NULL,
+  source_result_id BIGINT,
+  penalty          TEXT,
+  team_id          BIGINT    NOT NULL,
+  team_name        TEXT      NOT NULL,
+  athletes_count   INTEGER   NOT NULL,
+  age_group        TEXT,
+  para_class       TEXT,
+  bib              TEXT,
+  total            INTEGER,
+  points           INTEGER,
+  cumulative_rank  INTEGER,
+  version          INTEGER   NOT NULL DEFAULT 0,
+  created_at       TIMESTAMP NOT NULL,
+  updated_at       TIMESTAMP,
+  CONSTRAINT pk_team_result PRIMARY KEY (id),
+  CONSTRAINT fk_team_result_race_id
+    FOREIGN KEY (race_id) REFERENCES race(id) ON DELETE CASCADE,
+  CONSTRAINT fk_team_result_team_result_id
+    FOREIGN KEY (source_result_id) REFERENCES team_result(id),
+  CONSTRAINT fk_team_result_team_id
+    FOREIGN KEY (team_id) REFERENCES team(id)
+);
+
+-- Create a dependency between the seq_team_result_id sequence and the team_result table primary key
+ALTER SEQUENCE IF EXISTS seq_team_result_id OWNED BY team_result.id;
+
+-- Create indexes on the team_result table
+CREATE INDEX IF NOT EXISTS idx_team_result_race_id ON team_result (race_id);
+CREATE INDEX IF NOT EXISTS idx_team_result_team_id ON team_result (team_id);
+CREATE INDEX IF NOT EXISTS idx_team_result_source_result_id ON team_result (source_result_id);
+
+-- Create the team_result_individual_result table
+CREATE TABLE IF NOT EXISTS team_result_individual_result (
+  team_result_id      BIGINT NOT NULL,
+  individual_result_id BIGINT NOT NULL,
+  CONSTRAINT pk_team_result_individual_result PRIMARY KEY (team_result_id, individual_result_id),
+  CONSTRAINT fk_team_result_individual_result_team_result_id
+    FOREIGN KEY (team_result_id) REFERENCES team_result(id) ON DELETE CASCADE,
+  CONSTRAINT fk_team_result_individual_result_individual_result_id
+    FOREIGN KEY (individual_result_id) REFERENCES individual_result(id) ON DELETE CASCADE
+);
+-- Create indexes on the team_result_individual_result table
+CREATE INDEX IF NOT EXISTS idx_team_result_individual_result_individual_result_id
+  ON team_result_individual_result (individual_result_id);

--- a/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V20260620.001__create-result-data-model-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/ddl/postgres/V20260620.001__create-result-data-model-postgres.sql
@@ -21,7 +21,7 @@
 -- Description: Creates the athlete, team, para_class, individual_result, team_result,
 --   and team_result_individual_result tables
 
-SET search_path TO endurancetrio_community;
+SET search_path TO endurancetrio_hub;
 
 -- Drop the age_group_id column from the race table
 DROP INDEX IF EXISTS idx_race_age_group_id;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.002__insert-1984-portuguese-triathlon-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.002__insert-1984-portuguese-triathlon-data-h2.sql
@@ -21,131 +21,131 @@
 -- Description: Inserts the data of the 1984 triathlon related events in Portugal
 --
 
--- endurancetrio_community.event table
+-- endurancetrio_hub.event table
 --
 INSERT INTO
-  endurancetrio_community.event (id, event_reference, title, start_date, end_date, city, county, district)
+  endurancetrio_hub.event (id, event_reference, title, start_date, end_date, city, county, district)
 VALUES
   (1, '19840815NAC001', 'Triatlo de Peniche', '1984-08-15', '1984-08-15', 'Peniche', 'Peniche', 'Leiria');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_id RESTART WITH 2;
+ALTER SEQUENCE endurancetrio_hub.seq_event_id RESTART WITH 2;
 
 
--- endurancetrio_community.organizer table
+-- endurancetrio_hub.organizer table
 --
 INSERT INTO
-  endurancetrio_community.organizer (id, name, city, county, district, organizer_type)
+  endurancetrio_hub.organizer (id, name, city, county, district, organizer_type)
 VALUES
   (1, 'Nuno Bello Conceição', 'Peniche', 'Peniche', 'Leiria', 'PRIVATE'),
   (2, 'Câmara Municipal de Peniche', 'Peniche', 'Peniche', 'Leiria', 'PUBLIC');
 
-ALTER SEQUENCE endurancetrio_community.seq_organizer_id RESTART WITH 3;
+ALTER SEQUENCE endurancetrio_hub.seq_organizer_id RESTART WITH 3;
 
 
--- endurancetrio_community.event_organizer table
+-- endurancetrio_hub.event_organizer table
 --
 INSERT INTO
-  endurancetrio_community.event_organizer (event_id, organizer_id)
+  endurancetrio_hub.event_organizer (event_id, organizer_id)
 VALUES
   (1, 1),
   (1, 2);
 
 
--- endurancetrio_community.event_file table
+-- endurancetrio_hub.event_file table
 --
 INSERT INTO
-  endurancetrio_community.event_file (id, event_id, title, revision, is_active, file_name, file_type)
+  endurancetrio_hub.event_file (id, event_id, title, revision, is_active, file_name, file_type)
 VALUES
   (1, 1, 'Cartaz', 1, true, '19840815NAC001-IMG001-01.jpg', 'POSTER'),
   (2, 1, 'Regulamento', 1, true, '19840815NAC001-REG001-01.pdf', 'RULES');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_file_id RESTART WITH 3;
+ALTER SEQUENCE endurancetrio_hub.seq_event_file_id RESTART WITH 3;
 
 
--- endurancetrio_community.distance table
+-- endurancetrio_hub.distance table
 --
 INSERT INTO
-  endurancetrio_community.distance (id, distance_type)
+  endurancetrio_hub.distance (id, distance_type)
 VALUES
   (1, 'SPRINT');
 
-ALTER SEQUENCE endurancetrio_community.seq_distance_id RESTART WITH 2;
+ALTER SEQUENCE endurancetrio_hub.seq_distance_id RESTART WITH 2;
 
 
--- endurancetrio_community.triathlon_distance table
+-- endurancetrio_hub.triathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (1, 600, 1, 17000, 1, 8000, 1);
 
 
--- endurancetrio_community.course table
+-- endurancetrio_hub.course table
 --
 INSERT INTO
-  endurancetrio_community.course (id, event_id, title, sport, distance_id)
+  endurancetrio_hub.course (id, event_id, title, sport, distance_id)
 VALUES
   (1, 1, 'Triatlo Sprint', 'TRIATHLON', 1);
 
-ALTER SEQUENCE endurancetrio_community.seq_course_id RESTART WITH 2;
+ALTER SEQUENCE endurancetrio_hub.seq_course_id RESTART WITH 2;
 
 
--- endurancetrio_community.age_group table
+-- endurancetrio_hub.age_group table
 --
 INSERT INTO
-  endurancetrio_community.age_group (id, title, short_title)
+  endurancetrio_hub.age_group (id, title, short_title)
 VALUES
   (1, 'Overall', 'OVR');
 
-ALTER SEQUENCE endurancetrio_community.seq_age_group_id RESTART WITH 2;
+ALTER SEQUENCE endurancetrio_hub.seq_age_group_id RESTART WITH 2;
 
 
--- endurancetrio_community.race table
+-- endurancetrio_hub.race table
 --
 INSERT INTO
-  endurancetrio_community.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
+  endurancetrio_hub.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
 VALUES
   (1, '19840815NAC001-001', 'Triatlo de Peniche', 'Geral', 'OPEN', 1, 'INDIVIDUAL_PARENT', '1984-08-15', '16:00:00', null, null, 'COMPLETED'),
   (2, '19840815NAC001-002', 'Triatlo de Peniche', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1984-08-15', '16:00:00', null, null, 'COMPLETED'),
   (3, '19840815NAC001-003', 'Triatlo de Peniche', 'Masculinos', 'MALE', 1, 'INDIVIDUAL_DERIVED', '1984-08-15', '16:00:00', null, null, 'PLANNED');
 
-ALTER SEQUENCE endurancetrio_community.seq_race_id RESTART WITH 4;
+ALTER SEQUENCE endurancetrio_hub.seq_race_id RESTART WITH 4;
 
 
--- endurancetrio_community.triathlon_based_race table
+-- endurancetrio_hub.triathlon_based_race table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_based_race (id, water_temperature, wetsuit_rule)
+  endurancetrio_hub.triathlon_based_race (id, water_temperature, wetsuit_rule)
 VALUES
   (1, null, 'UNKNOWN'),
   (2, null, 'UNKNOWN'),
   (3, null, 'UNKNOWN');
 
 
--- endurancetrio_community.course_race table
+-- endurancetrio_hub.course_race table
 --
 INSERT INTO
-  endurancetrio_community.course_race (course_id, race_id)
+  endurancetrio_hub.course_race (course_id, race_id)
 VALUES
   (1, 1),
   (1, 2),
   (1, 3);
 
 
--- endurancetrio_community.race_hierarchy table
+-- endurancetrio_hub.race_hierarchy table
 --
 INSERT INTO
-  endurancetrio_community.race_hierarchy (race_id, parent_race_id)
+  endurancetrio_hub.race_hierarchy (race_id, parent_race_id)
 VALUES
   (2, 1),
   (3, 1);
 
 
--- endurancetrio_community.results_file table
+-- endurancetrio_hub.results_file table
 --
 INSERT INTO
-  endurancetrio_community.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
+  endurancetrio_hub.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
 VALUES
   (1, 1, 'Triatlo de Peniche', 'Geral', 1, true, '19840815NAC001-001A-01.pdf');
 
-ALTER SEQUENCE endurancetrio_community.seq_results_file_id RESTART WITH 2;
+ALTER SEQUENCE endurancetrio_hub.seq_results_file_id RESTART WITH 2;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.003__insert-1985-portuguese-triathlon-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.003__insert-1985-portuguese-triathlon-data-h2.sql
@@ -20,32 +20,32 @@
 
 -- Description: Inserts the data of the 1985 triathlon related events in Portugal
 
--- endurancetrio_community.event table
+-- endurancetrio_hub.event table
 --
 INSERT INTO
-  endurancetrio_community.event (id, event_reference, title, start_date, end_date, city, county, district)
+  endurancetrio_hub.event (id, event_reference, title, start_date, end_date, city, county, district)
 VALUES
   (2, '19850629NAC001', 'Triatlo de Cascais', '1985-06-29', '1985-06-29', 'Cascais', 'Cascais', 'Lisboa'),
   (3, '19850815NAC001', 'Triatlo de Peniche', '1985-08-15', '1985-08-15', 'Peniche', 'Peniche', 'Leiria');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_id RESTART WITH 4;
+ALTER SEQUENCE endurancetrio_hub.seq_event_id RESTART WITH 4;
 
 
--- endurancetrio_community.organizer table
+-- endurancetrio_hub.organizer table
 --
 INSERT INTO
-  endurancetrio_community.organizer (id, name, city, county, district, organizer_type)
+  endurancetrio_hub.organizer (id, name, city, county, district, organizer_type)
 VALUES
   (3, 'Empresa Pública Notícias e Capital', 'Lisboa', 'Lisboa', 'Lisboa', 'PRIVATE'),
   (4, 'Câmara Municipal de Cascais', 'Cascais', 'Cascais', 'Lisboa', 'PUBLIC');
 
-ALTER SEQUENCE endurancetrio_community.seq_organizer_id RESTART WITH 5;
+ALTER SEQUENCE endurancetrio_hub.seq_organizer_id RESTART WITH 5;
 
 
--- endurancetrio_community.event_organizer table
+-- endurancetrio_hub.event_organizer table
 --
 INSERT INTO
-  endurancetrio_community.event_organizer (event_id, organizer_id)
+  endurancetrio_hub.event_organizer (event_id, organizer_id)
 VALUES
   (2, 3),
   (2, 4),
@@ -53,54 +53,54 @@ VALUES
   (3, 2);
 
 
--- endurancetrio_community.event_file table
+-- endurancetrio_hub.event_file table
 --
 INSERT INTO
-  endurancetrio_community.event_file (id, event_id, title, revision, is_active, file_name, file_type)
+  endurancetrio_hub.event_file (id, event_id, title, revision, is_active, file_name, file_type)
 VALUES
   (3, 2, 'Cartaz', 1, true, '19850629NAC001-IMG001-01.jpg', 'POSTER'),
   (4, 2, 'Regulamento', 1, true, '19850629NAC001-REG001-01.pdf', 'RULES'),
   (5, 2, 'Percurso', 1, true, '19850629NAC001-MAP001-01,pdf', 'RULES'),
   (6, 3, 'Cartaz', 1, true, '19850815NAC001-IMG001-01.jpg', 'POSTER');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_file_id RESTART WITH 7;
+ALTER SEQUENCE endurancetrio_hub.seq_event_file_id RESTART WITH 7;
 
 
--- endurancetrio_community.distance table
+-- endurancetrio_hub.distance table
 --
 INSERT INTO
-  endurancetrio_community.distance (id, distance_type)
+  endurancetrio_hub.distance (id, distance_type)
 VALUES
   (2, 'STANDARD'),
   (3, 'SPRINT');
 
-ALTER SEQUENCE endurancetrio_community.seq_distance_id RESTART WITH 5;
+ALTER SEQUENCE endurancetrio_hub.seq_distance_id RESTART WITH 5;
 
 
--- endurancetrio_community.triathlon_distance table
+-- endurancetrio_hub.triathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (2, 1000, 1, 45000, 1, 10000, 1),
   (3, 600, 1, 17000, 1, 8000, 1);
 
 
--- endurancetrio_community.course table
+-- endurancetrio_hub.course table
 --
 INSERT INTO
-  endurancetrio_community.course (id, event_id, title, sport, distance_id)
+  endurancetrio_hub.course (id, event_id, title, sport, distance_id)
 VALUES
   (2, 2, 'Triatlo Standard', 'TRIATHLON', 2),
   (3, 3, 'Triatlo Sprint', 'TRIATHLON', 3);
 
-ALTER SEQUENCE endurancetrio_community.seq_course_id RESTART WITH 4;
+ALTER SEQUENCE endurancetrio_hub.seq_course_id RESTART WITH 4;
 
 
--- endurancetrio_community.race table
+-- endurancetrio_hub.race table
 --
 INSERT INTO
-  endurancetrio_community.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
+  endurancetrio_hub.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
 VALUES
   (4, '19850629NAC001-001', 'Triatlo de Cascais', 'Geral', 'OPEN', 1, 'INDIVIDUAL_PARENT', '1985-06-29', '10:30:00', null, null, 'COMPLETED'),
   (5, '19850629NAC001-002', 'Triatlo de Cascais', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1985-06-29', '10:30:00', null, null, 'COMPLETED'),
@@ -109,13 +109,13 @@ VALUES
   (8, '19850815NAC001-002', 'Triatlo de Peniche', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1985-08-15', '10:00:00', null, null, 'COMPLETED'),
   (9, '19850815NAC001-003', 'Triatlo de Peniche', 'Masculinos', 'MALE', 1, 'INDIVIDUAL_DERIVED', '1985-08-15', '10:00:00', null, null, 'COMPLETED');
 
-ALTER SEQUENCE endurancetrio_community.seq_race_id RESTART WITH 10;
+ALTER SEQUENCE endurancetrio_hub.seq_race_id RESTART WITH 10;
 
 
--- endurancetrio_community.triathlon_based_race table
+-- endurancetrio_hub.triathlon_based_race table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_based_race (id, water_temperature, wetsuit_rule)
+  endurancetrio_hub.triathlon_based_race (id, water_temperature, wetsuit_rule)
 VALUES
   (4, null, 'UNKNOWN'),
   (5, null, 'UNKNOWN'),
@@ -125,10 +125,10 @@ VALUES
   (9, null, 'UNKNOWN');
 
 
--- endurancetrio_community.course_race table
+-- endurancetrio_hub.course_race table
 --
 INSERT INTO
-  endurancetrio_community.course_race (course_id, race_id)
+  endurancetrio_hub.course_race (course_id, race_id)
 VALUES
   (2, 4),
   (2, 5),
@@ -138,10 +138,10 @@ VALUES
   (3, 9);
 
 
--- endurancetrio_community.race_hierarchy table
+-- endurancetrio_hub.race_hierarchy table
 --
 INSERT INTO
-  endurancetrio_community.race_hierarchy (race_id, parent_race_id)
+  endurancetrio_hub.race_hierarchy (race_id, parent_race_id)
 VALUES
   (5, 4),
   (6, 4),
@@ -149,12 +149,12 @@ VALUES
   (9, 7);
 
 
--- endurancetrio_community.results_file table
+-- endurancetrio_hub.results_file table
 --
 INSERT INTO
-  endurancetrio_community.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
+  endurancetrio_hub.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
 VALUES
   (2, 4, 'Triatlo de Cascais', 'Geral', 1, true, '19850629NAC001-001A-01.pdf'),
   (3, 7, 'Triatlo de Peniche', 'Geral', 1, true, '19850815NAC001-001A-01.pdf');
 
-ALTER SEQUENCE endurancetrio_community.seq_results_file_id RESTART WITH 4;
+ALTER SEQUENCE endurancetrio_hub.seq_results_file_id RESTART WITH 4;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.004__insert-1986-portuguese-triathlon-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.004__insert-1986-portuguese-triathlon-data-h2.sql
@@ -20,10 +20,10 @@
 
 -- Description: Inserts the data of the 1986 triathlon related events in Portugal
 
--- endurancetrio_community.event table
+-- endurancetrio_hub.event table
 --
 INSERT INTO
-  endurancetrio_community.event (id, event_reference, title, start_date, end_date, city, county, district)
+  endurancetrio_hub.event (id, event_reference, title, start_date, end_date, city, county, district)
 VALUES
   (4, '19860531NAC001', 'Triatlo UNICEF Setúbal', '1986-05-31', '1986-05-31', 'Setúbal', 'Setúbal', 'Setúbal'),
   (5, '19860614NAC001', 'Triatlo de Cascais', '1986-06-14', '1986-06-14', 'Cascais', 'Cascais', 'Lisboa'),
@@ -31,24 +31,24 @@ VALUES
   (7, '19860815NAC001', 'Triatlo de Peniche', '1986-08-15', '1986-08-15', 'Peniche', 'Peniche', 'Leiria'),
   (8, '19860913NAC001', 'Triatlo de Tancos', '1986-09-13', '1986-09-13', 'Santa Margarida', 'Vila Nova da Barquinha', 'Santarém');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_id RESTART WITH 9;
+ALTER SEQUENCE endurancetrio_hub.seq_event_id RESTART WITH 9;
 
 
--- endurancetrio_community.organizer table
+-- endurancetrio_hub.organizer table
 --
 INSERT INTO
-  endurancetrio_community.organizer (id, name, city, county, district, organizer_type)
+  endurancetrio_hub.organizer (id, name, city, county, district, organizer_type)
 VALUES
   (5, 'Organizador #5', 'Espinho', 'Espinho', 'Aveiro', 'PRIVATE'),
   (6, 'Pára-Clube Nacional "Os Bóinas Verdes"', 'Tancos', 'Santarém', 'Santarém', 'CLUB');
 
-ALTER SEQUENCE endurancetrio_community.seq_organizer_id RESTART WITH 7;
+ALTER SEQUENCE endurancetrio_hub.seq_organizer_id RESTART WITH 7;
 
 
--- endurancetrio_community.event_organizer table
+-- endurancetrio_hub.event_organizer table
 --
 INSERT INTO
-  endurancetrio_community.event_organizer (event_id, organizer_id)
+  endurancetrio_hub.event_organizer (event_id, organizer_id)
 VALUES
   (4, 3),
   (5, 3),
@@ -58,10 +58,10 @@ VALUES
   (8, 6);
 
 
--- endurancetrio_community.event_file table
+-- endurancetrio_hub.event_file table
 --
 INSERT INTO
-  endurancetrio_community.event_file (id, event_id, title, revision, is_active, file_name, file_type)
+  endurancetrio_hub.event_file (id, event_id, title, revision, is_active, file_name, file_type)
 VALUES
   (7, 4, 'Regulamento', 1, true, '19860531NAC001-REG001-01.pdf', 'RULES'),
   (8, 4, 'Percursos', 1, true, '19860531NAC001-MAP001-01.pdf', 'COURSE_MAPS'),
@@ -73,26 +73,26 @@ VALUES
   (14, 8, 'Regulamento', 1, true, '19860913NAC001-REG001-01.pdf', 'RULES'),
   (15, 8, 'Percursos', 1, true, '19860913NAC001-MAP001-01.pdf', 'COURSE_MAPS');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_file_id RESTART WITH 16;
+ALTER SEQUENCE endurancetrio_hub.seq_event_file_id RESTART WITH 16;
 
 
--- endurancetrio_community.distance table
+-- endurancetrio_hub.distance table
 --
 INSERT INTO
-  endurancetrio_community.distance (id, distance_type)
+  endurancetrio_hub.distance (id, distance_type)
 VALUES
   (4, 'STANDARD'),
   (5, 'STANDARD'),
   (7, 'STANDARD'),
   (8, 'STANDARD');
 
-ALTER SEQUENCE endurancetrio_community.seq_distance_id RESTART WITH 9;
+ALTER SEQUENCE endurancetrio_hub.seq_distance_id RESTART WITH 9;
 
 
--- endurancetrio_community.triathlon_distance table
+-- endurancetrio_hub.triathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (4, 1000, 1, 40000, 1, 10000, 1),
   (5, 1000, 1, 45000, 1, 10000, 1),
@@ -100,10 +100,10 @@ VALUES
   (8, 1000, 1, 45000, 1, 10000, 1);
 
 
--- endurancetrio_community.course table
+-- endurancetrio_hub.course table
 --
 INSERT INTO
-  endurancetrio_community.course (id, event_id, title, sport, distance_id)
+  endurancetrio_hub.course (id, event_id, title, sport, distance_id)
 VALUES
   (4, 4, 'Triatlo Standard', 'TRIATHLON', 4),
   (5, 5, 'Triatlo Standard', 'TRIATHLON', 5),
@@ -111,13 +111,13 @@ VALUES
   (7, 7, 'Triatlo Standard', 'TRIATHLON', 7),
   (8, 8, 'Triatlo Standard', 'TRIATHLON', 8);
 
-ALTER SEQUENCE endurancetrio_community.seq_course_id RESTART WITH 9;
+ALTER SEQUENCE endurancetrio_hub.seq_course_id RESTART WITH 9;
 
 
--- endurancetrio_community.race table
+-- endurancetrio_hub.race table
 --
 INSERT INTO
-  endurancetrio_community.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
+  endurancetrio_hub.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
 VALUES
   (10, '19860531NAC001-001', 'Triatlo UNICEF Setúbal', 'Geral', 'OPEN', 1, 'INDIVIDUAL_PARENT', '1986-05-31', '13:00:00', null, null, 'COMPLETED'),
   (11, '19860531NAC001-002', 'Triatlo UNICEF Setúbal', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1986-05-31', '13:00:00', null, null, 'COMPLETED'),
@@ -132,13 +132,13 @@ VALUES
   (20, '19860913NAC001-002', 'Triatlo de Tancos', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1986-09-13', '13:00:00', null, null, 'COMPLETED'),
   (21, '19860913NAC001-003', 'Triatlo de Tancos', 'Masculinos', 'MALE', 1, 'INDIVIDUAL_DERIVED', '1986-09-13', '13:00:00', null, null, 'COMPLETED');
 
-ALTER SEQUENCE endurancetrio_community.seq_race_id RESTART WITH 22;
+ALTER SEQUENCE endurancetrio_hub.seq_race_id RESTART WITH 22;
 
 
--- endurancetrio_community.triathlon_based_race table
+-- endurancetrio_hub.triathlon_based_race table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_based_race (id, water_temperature, wetsuit_rule)
+  endurancetrio_hub.triathlon_based_race (id, water_temperature, wetsuit_rule)
 VALUES
   (10, null, 'UNKNOWN'),
   (11, null, 'UNKNOWN'),
@@ -154,10 +154,10 @@ VALUES
   (21, null, 'UNKNOWN');
 
 
--- endurancetrio_community.course_race table
+-- endurancetrio_hub.course_race table
 --
 INSERT INTO
-  endurancetrio_community.course_race (course_id, race_id)
+  endurancetrio_hub.course_race (course_id, race_id)
 VALUES
   (4, 10),
   (4, 11),
@@ -173,10 +173,10 @@ VALUES
   (7, 21);
 
 
--- endurancetrio_community.race_hierarchy table
+-- endurancetrio_hub.race_hierarchy table
 --
 INSERT INTO
-  endurancetrio_community.race_hierarchy (race_id, parent_race_id)
+  endurancetrio_hub.race_hierarchy (race_id, parent_race_id)
 VALUES
   (10, 10),
   (11, 10),
@@ -188,14 +188,14 @@ VALUES
   (20, 19);
 
 
--- endurancetrio_community.results_file table
+-- endurancetrio_hub.results_file table
 --
 INSERT INTO
-  endurancetrio_community.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
+  endurancetrio_hub.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
 VALUES
   (9, 10, 'Triatlo UNICEF Setúbal', 'Geral', 1, true, '19860531NAC001-001A-01.pdf'),
   (10, 13, 'Triatlo de Cascais', 'Geral', 1, true, '19860614NAC001-001A-01.pdf'),
   (11, 16, 'Triatlo de Peniche', 'Geral', 1, true, '19860815NAC001-001A-01.pdf'),
   (12, 19, 'Triatlo de Tancos', 'Geral', 1, true, '19860913NAC001-001A-01.pdf');
 
-ALTER SEQUENCE endurancetrio_community.seq_results_file_id RESTART WITH 13;
+ALTER SEQUENCE endurancetrio_hub.seq_results_file_id RESTART WITH 13;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.005__insert-1987-portuguese-triathlon-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.005__insert-1987-portuguese-triathlon-data-h2.sql
@@ -20,10 +20,10 @@
 
 -- Description: Inserts the data of the 1987 triathlon related events in Portugal
 
--- endurancetrio_community.event table
+-- endurancetrio_hub.event table
 --
 INSERT INTO
-  endurancetrio_community.event (id, event_reference, title, start_date, end_date, city, county, district)
+  endurancetrio_hub.event (id, event_reference, title, start_date, end_date, city, county, district)
 VALUES
   (9, '19870111APT001', 'I Duplo Biatlo de Tomar', '1987-01-11', '1987-01-11', 'Tomar', 'Tomar', 'Santarém'),
   (10, '19870118APT001', 'I Triatlo Experimental de Braga', '1987-01-18', '1987-01-18', 'Braga', 'Braga', 'Braga'),
@@ -41,13 +41,13 @@ VALUES
   (22, '19871004APT001', '1º Triatlo de Lagos', '1987-10-04', '1987-10-04', 'Lagos', 'Lagos', 'Faro'),
   (23, '19871018APT001', 'I Triatlo de Grândola', '1987-10-18', '1987-10-18', 'Grândola', 'Grândola', 'Setúbal');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_id RESTART WITH 24;
+ALTER SEQUENCE endurancetrio_hub.seq_event_id RESTART WITH 24;
 
 
--- endurancetrio_community.organizer table
+-- endurancetrio_hub.organizer table
 --
 INSERT INTO
-  endurancetrio_community.organizer (id, name, city, county, district, organizer_type)
+  endurancetrio_hub.organizer (id, name, city, county, district, organizer_type)
 VALUES
   (7, 'Clube de Actividades de Lazer e Manutenção', 'Tomar', 'Tomar', 'Santarém', 'CLUB'),
   (8, 'Câmara Municipal de Braga', 'Braga', 'Braga', 'Braga', 'PUBLIC'),
@@ -65,13 +65,13 @@ VALUES
   (20, 'Câmara Municipal de Grândola', 'Grândola', 'Grândola', 'Setúbal', 'PUBLIC'),
   (21, 'Clube de Ténis de Grândola', 'Grândola', 'Grândola', 'Setúbal', 'CLUB');
 
-ALTER SEQUENCE endurancetrio_community.seq_organizer_id RESTART WITH 22;
+ALTER SEQUENCE endurancetrio_hub.seq_organizer_id RESTART WITH 22;
 
 
--- endurancetrio_community.event_organizer table
+-- endurancetrio_hub.event_organizer table
 --
 INSERT INTO
-  endurancetrio_community.event_organizer (event_id, organizer_id)
+  endurancetrio_hub.event_organizer (event_id, organizer_id)
 VALUES
   (9, 7),
   (10, 8),
@@ -93,10 +93,10 @@ VALUES
   (23, 21);
 
 
--- endurancetrio_community.event_file table
+-- endurancetrio_hub.event_file table
 --
 INSERT INTO
-  endurancetrio_community.event_file (id, event_id, title, revision, is_active, file_name, file_type)
+  endurancetrio_hub.event_file (id, event_id, title, revision, is_active, file_name, file_type)
 VALUES
   (16, 9, 'Cartaz', 1, true, '19870111APT001-IMG001-01.png', 'POSTER'),
   (17, 9, 'Regulamento', 1, true, '19870111APT001-REG001-01.pdf', 'RULES'),
@@ -132,13 +132,13 @@ VALUES
   (47, 23, 'Cartaz', 1, true, '19871018APT001-IMG001-01.png', 'POSTER'),
   (48, 23, 'Regulamento', 1, true, '19871018APT001-REG001-01.pdf', 'RULES');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_file_id RESTART WITH 49;
+ALTER SEQUENCE endurancetrio_hub.seq_event_file_id RESTART WITH 49;
 
 
--- endurancetrio_community.distance table
+-- endurancetrio_hub.distance table
 --
 INSERT INTO
-  endurancetrio_community.distance (id, distance_type)
+  endurancetrio_hub.distance (id, distance_type)
 VALUES
   (9, 'SPRINT'),
   (10, 'SPRINT'),
@@ -157,13 +157,13 @@ VALUES
   (23, 'STANDARD'),
   (24, 'STANDARD');
 
-ALTER SEQUENCE endurancetrio_community.seq_distance_id RESTART WITH 25;
+ALTER SEQUENCE endurancetrio_hub.seq_distance_id RESTART WITH 25;
 
 
--- endurancetrio_community.biathlon_distance table
+-- endurancetrio_hub.biathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.biathlon_distance (id, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.biathlon_distance (id, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (11, 50000, 1, 10000, 1),
   (12, 40000, 1, 10000, 1),
@@ -171,18 +171,18 @@ VALUES
   (14, 66000, 1, 16000, 1);
 
 
--- endurancetrio_community.double_biathlon_distance table
+-- endurancetrio_hub.double_biathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.double_biathlon_distance (id, first_bike_distance, first_bike_laps, first_run_distance, first_run_laps, second_bike_distance, second_bike_laps, second_run_distance, second_run_laps)
+  endurancetrio_hub.double_biathlon_distance (id, first_bike_distance, first_bike_laps, first_run_distance, first_run_laps, second_bike_distance, second_bike_laps, second_run_distance, second_run_laps)
 VALUES
   (9, 15000, 1, 5000, 1, 15000, 1, 5000, 1);
 
 
--- endurancetrio_community.triathlon_distance table
+-- endurancetrio_hub.triathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (10, 250, 3, 20000, 1, 5000, 1),
   (15, 800, 1, 35000, 1, 8000, 1),
@@ -197,10 +197,10 @@ VALUES
   (24, 1000, 1, 48000, 1, 10000, 1);
 
 
--- endurancetrio_community.course table
+-- endurancetrio_hub.course table
 --
 INSERT INTO
-  endurancetrio_community.course (id, event_id, title, sport, distance_id)
+  endurancetrio_hub.course (id, event_id, title, sport, distance_id)
 VALUES
   (9, 9, 'Duplo Biatlo Sprint', 'DOUBLE_BIATHLON', 9),
   (10, 10, 'Triatlo Sprint', 'TRIATHLON', 10),
@@ -219,13 +219,13 @@ VALUES
   (23, 22, 'Triatlo Standard', 'TRIATHLON', 23),
   (24, 23, 'Triatlo Standard', 'TRIATHLON', 24);
 
-ALTER SEQUENCE endurancetrio_community.seq_course_id RESTART WITH 25;
+ALTER SEQUENCE endurancetrio_hub.seq_course_id RESTART WITH 25;
 
 
--- endurancetrio_community.race table
+-- endurancetrio_hub.race table
 --
 INSERT INTO
-  endurancetrio_community.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
+  endurancetrio_hub.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
 VALUES
   (22, '19870111APT001-001', 'I Duplo Biatlo de Tomar', 'Geral', 'OPEN', 1, 'INDIVIDUAL_PARENT', '1987-01-11', '11:00:00', null, null, 'COMPLETED'),
   (23, '19870111APT001-002', 'I Duplo Biatlo de Tomar', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1987-01-11', '11:00:00', null, null, 'COMPLETED'),
@@ -298,13 +298,13 @@ VALUES
   (90, '19871018APT001-004', 'I Triatlo de Grândola', 'Equipas Femininas', 'FEMALE', 1, 'TEAM_BY_TIME', '1987-10-18', '11:00:00', null, null, 'PLANNED'),
   (91, '19871018APT001-005', 'I Triatlo de Grândola', 'Equipas Masculinas', 'MALE', 1, 'TEAM_BY_TIME', '1987-10-18', '11:00:00', null, null, 'COMPLETED');
 
-ALTER SEQUENCE endurancetrio_community.seq_race_id RESTART WITH 92;
+ALTER SEQUENCE endurancetrio_hub.seq_race_id RESTART WITH 92;
 
 
--- endurancetrio_community.triathlon_based_race table
+-- endurancetrio_hub.triathlon_based_race table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_based_race (id, water_temperature, wetsuit_rule)
+  endurancetrio_hub.triathlon_based_race (id, water_temperature, wetsuit_rule)
 VALUES
   (44, null, 'UNKNOWN'),
   (45, null, 'UNKNOWN'),
@@ -356,10 +356,10 @@ VALUES
   (91, null, 'UNKNOWN');
 
 
--- endurancetrio_community.course_race table
+-- endurancetrio_hub.course_race table
 --
 INSERT INTO
-  endurancetrio_community.course_race (course_id, race_id)
+  endurancetrio_hub.course_race (course_id, race_id)
 VALUES
   (9, 22),
   (9, 23),
@@ -431,10 +431,10 @@ VALUES
   (24, 91);
 
 
--- endurancetrio_community.race_hierarchy table
+-- endurancetrio_hub.race_hierarchy table
 --
 INSERT INTO
-  endurancetrio_community.race_hierarchy (race_id, parent_race_id)
+  endurancetrio_hub.race_hierarchy (race_id, parent_race_id)
 VALUES
   (23, 22),
   (24, 22),
@@ -492,10 +492,10 @@ VALUES
   (91, 89);
 
 
--- endurancetrio_community.results_file table
+-- endurancetrio_hub.results_file table
 --
 INSERT INTO
-  endurancetrio_community.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
+  endurancetrio_hub.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
 VALUES
   (13, 22, 'I Duplo Biatlo de Tomar', 'Geral', 1, true, '19870111APT001-001A-01.pdf'),
   (14, 25, 'I Triatlo Experimental de Braga', 'Geral', 1, true, '19870118APT001-001A-01.pdf'),
@@ -517,4 +517,4 @@ VALUES
   (30, 86, '1º Triatlo de Lagos', 'Equipas Masculinas', 1, true, '19871004APT001-005A-01.pdf'),
   (31, 87, 'I Triatlo de Grândola', 'Geral', 1, true, '19871018APT001-001A-01.pdf');
 
-ALTER SEQUENCE endurancetrio_community.seq_results_file_id RESTART WITH 32;
+ALTER SEQUENCE endurancetrio_hub.seq_results_file_id RESTART WITH 32;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.006__insert-1988-portuguese-triathlon-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.006__insert-1988-portuguese-triathlon-data-h2.sql
@@ -20,10 +20,10 @@
 
 -- Description: Inserts the data of the 1988 triathlon related events in Portugal
 
--- endurancetrio_community.event table
+-- endurancetrio_hub.event table
 --
 INSERT INTO
-  endurancetrio_community.event (id, event_reference, title, start_date, end_date, city, county, district)
+  endurancetrio_hub.event (id, event_reference, title, start_date, end_date, city, county, district)
 VALUES
   (24, '19880313APT001', '1º Biatlo de Porto de Mós', '1988-03-13', '1988-03-13', 'Porto de Mós', 'Porto de Mós', 'Leiria'),
   (25, '19880402APT001', '2º Biatlo do Porto', '1988-04-02', '1988-04-02', 'Porto', 'Porto', 'Porto'),
@@ -42,13 +42,13 @@ VALUES
   (38, '19880918APT001', '2º Triatlo de Ponte de Sor', '1988-09-18', '1988-09-18', 'Ponde de Sor', 'Ponte de Sor', 'Portalegre'),
   (39, '19880925APT001', 'Triatlo de Lagos', '1988-09-25', '1988-09-25', 'Lagos', 'Lagos', 'Faro');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_id RESTART WITH 40;
+ALTER SEQUENCE endurancetrio_hub.seq_event_id RESTART WITH 40;
 
 
--- endurancetrio_community.organizer table
+-- endurancetrio_hub.organizer table
 --
 INSERT INTO
-  endurancetrio_community.organizer (id, name, city, county, district, organizer_type)
+  endurancetrio_hub.organizer (id, name, city, county, district, organizer_type)
 VALUES
   (22, 'Câmara Municipal de Porto de Mós', 'Porto de Mós', 'Porto de Mós', 'Leiria', 'PUBLIC'),
   (23, 'Câmara Municipal de Oliveira de Azemeis', 'Oliveira de Azeméis', 'Oliveira de Azeméis', 'Aveiro', 'PUBLIC'),
@@ -63,13 +63,13 @@ VALUES
   (32, 'Câmara Municipal de Óbidos', 'Óbidos', 'Óbidos', 'Leiria', 'PUBLIC'),
   (33, 'Câmara Municipal de Lagos', 'Lagos', 'Lagos', 'Faro', 'PUBLIC');
 
-ALTER SEQUENCE endurancetrio_community.seq_organizer_id RESTART WITH 34;
+ALTER SEQUENCE endurancetrio_hub.seq_organizer_id RESTART WITH 34;
 
 
--- endurancetrio_community.event_organizer table
+-- endurancetrio_hub.event_organizer table
 --
 INSERT INTO
-  endurancetrio_community.event_organizer (event_id, organizer_id)
+  endurancetrio_hub.event_organizer (event_id, organizer_id)
 VALUES
   (24, 22),
   (24, 12),
@@ -108,10 +108,10 @@ VALUES
   (39, 12);
 
 
--- endurancetrio_community.event_file table
+-- endurancetrio_hub.event_file table
 --
 INSERT INTO
-  endurancetrio_community.event_file (id, event_id, title, revision, is_active, file_name, file_type)
+  endurancetrio_hub.event_file (id, event_id, title, revision, is_active, file_name, file_type)
 VALUES
   (49, 24, 'Regulamento', 1, true, '19880313APT001-REG001-01.pdf', 'RULES'),
   (50, 24, 'Percursos', 1, true, '19880313APT001-MAP001-01.pdf', 'COURSE_MAPS'),
@@ -142,13 +142,13 @@ VALUES
   (76, 39, 'Cartaz', 1, true, '19880925APT001-IMG001-01.png', 'POSTER'),
   (77, 39, 'Percursos', 1, true, '19880925APT001-MAP001-01.pdf', 'COURSE_MAPS');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_file_id RESTART WITH 78;
+ALTER SEQUENCE endurancetrio_hub.seq_event_file_id RESTART WITH 78;
 
 
--- endurancetrio_community.distance table
+-- endurancetrio_hub.distance table
 --
 INSERT INTO
-  endurancetrio_community.distance (id, distance_type)
+  endurancetrio_hub.distance (id, distance_type)
 VALUES
   (25, 'STANDARD'),
   (26, 'STANDARD'),
@@ -167,31 +167,31 @@ VALUES
   (39, 'STANDARD'),
   (40, 'STANDARD');
 
-ALTER SEQUENCE endurancetrio_community.seq_distance_id RESTART WITH 41;
+ALTER SEQUENCE endurancetrio_hub.seq_distance_id RESTART WITH 41;
 
 
--- endurancetrio_community.biathlon_distance table
+-- endurancetrio_hub.biathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.biathlon_distance (id, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.biathlon_distance (id, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (26, 40000, 1, 10000, 1);
 
 
--- endurancetrio_community.duathlon_distance table
+-- endurancetrio_hub.duathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.duathlon_distance (id, first_run_distance, first_run_laps, bike_distance, bike_laps, second_run_distance, second_run_laps)
+  endurancetrio_hub.duathlon_distance (id, first_run_distance, first_run_laps, bike_distance, bike_laps, second_run_distance, second_run_laps)
 VALUES
   (25, 5200, 1, 42000, 1, 5200, 1),
   (27, 4000, 1, 50000, 1, 10000, 1),
   (36, 5200, 1, 31200, 1, 5000, 1);
 
 
--- endurancetrio_community.triathlon_distance table
+-- endurancetrio_hub.triathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (28, 1000, 1, 43000, 1, 10000, 1),
   (29, 2000, 1, 84000, 2, 20000, 1),
@@ -207,10 +207,10 @@ VALUES
   (40, 1000, 1, 41000, 1, 10000, 1);
 
 
--- endurancetrio_community.course table
+-- endurancetrio_hub.course table
 --
 INSERT INTO
-  endurancetrio_community.course (id, event_id, title, sport, distance_id)
+  endurancetrio_hub.course (id, event_id, title, sport, distance_id)
 VALUES
   (25, 24, 'Duatlo Standard', 'DUATHLON', 25),
   (26, 25, 'Biatlo Standard', 'BIATHLON', 26),
@@ -229,13 +229,13 @@ VALUES
   (39, 38, 'Triatlo Standard', 'TRIATHLON', 39),
   (40, 39, 'Triatlo Standard', 'TRIATHLON', 40);
 
-ALTER SEQUENCE endurancetrio_community.seq_course_id RESTART WITH 41;
+ALTER SEQUENCE endurancetrio_hub.seq_course_id RESTART WITH 41;
 
 
--- endurancetrio_community.race table
+-- endurancetrio_hub.race table
 --
 INSERT INTO
-  endurancetrio_community.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
+  endurancetrio_hub.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
 VALUES
   (92, '19880313APT001-001', '1º Biatlo de Porto de Mós', 'Geral', 'OPEN', 1, 'INDIVIDUAL_PARENT', '1988-03-13', '11:00:00', null, null, 'COMPLETED'),
   (93, '19880313APT001-002', '1º Biatlo de Porto de Mós', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1988-03-13', '11:00:00', null, null, 'COMPLETED'),
@@ -310,13 +310,13 @@ VALUES
   (162, '19880925APT001-004', 'Triatlo de Lagos', 'Equipas femininas', 'FEMALE', 1, 'TEAM_BY_TIME', '1988-09-25', '13:00:00', null, null, 'PLANNED'),
   (163, '19880925APT001-005', 'Triatlo de Lagos', 'Equipas masculinas', 'MALE', 1, 'TEAM_BY_TIME', '1988-09-25', '13:00:00', null, null, 'COMPLETED');
 
-ALTER SEQUENCE endurancetrio_community.seq_race_id RESTART WITH 164;
+ALTER SEQUENCE endurancetrio_hub.seq_race_id RESTART WITH 164;
 
 
--- endurancetrio_community.triathlon_based_race table
+-- endurancetrio_hub.triathlon_based_race table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_based_race (id, water_temperature, wetsuit_rule)
+  endurancetrio_hub.triathlon_based_race (id, water_temperature, wetsuit_rule)
 VALUES
   (107, null, 'UNKNOWN'),
   (108, null, 'UNKNOWN'),
@@ -372,10 +372,10 @@ VALUES
   (163, null, 'UNKNOWN');
 
 
--- endurancetrio_community.course_race table
+-- endurancetrio_hub.course_race table
 --
 INSERT INTO
-  endurancetrio_community.course_race (course_id, race_id)
+  endurancetrio_hub.course_race (course_id, race_id)
 VALUES
   (25, 92),
   (25, 93),
@@ -447,10 +447,10 @@ VALUES
   (40, 163);
 
 
--- endurancetrio_community.race_hierarchy table
+-- endurancetrio_hub.race_hierarchy table
 --
 INSERT INTO
-  endurancetrio_community.race_hierarchy (race_id, parent_race_id)
+  endurancetrio_hub.race_hierarchy (race_id, parent_race_id)
 VALUES
   (93, 92),
   (94, 92),
@@ -508,10 +508,10 @@ VALUES
   (163, 161);
 
 
--- endurancetrio_community.results_file table
+-- endurancetrio_hub.results_file table
 --
 INSERT INTO
-  endurancetrio_community.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
+  endurancetrio_hub.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
 VALUES
   (32, 92, 'I Biatlo de Porto de Mós', 'Geral', 1, true, '19880313APT001-001A-01.pdf'),
   (33, 98, '2º Biatlo do Porto', 'Escalões Femininos', 1, true, '19880402APT001-002B-01.pdf'),
@@ -541,4 +541,4 @@ VALUES
   (57, 159, 'Triatlo de Lagos', 'Geral', 1, true, '19880925APT001-001A-01.pdf'),
   (58, 163, 'Triatlo de Lagos', 'Equipas Masculinas', 1, true, '19880925APT001-005A-01.pdf');
 
-ALTER SEQUENCE endurancetrio_community.seq_results_file_id RESTART WITH 59;
+ALTER SEQUENCE endurancetrio_hub.seq_results_file_id RESTART WITH 59;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.007__insert-1989-portuguese-triathlon-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.007__insert-1989-portuguese-triathlon-data-h2.sql
@@ -20,10 +20,10 @@
 
 -- Description: Inserts the data of the 1989 triathlon related events in Portugal
 
--- endurancetrio_community.event table
+-- endurancetrio_hub.event table
 --
 INSERT INTO
-  endurancetrio_community.event (id, event_reference, title, start_date, end_date, city, county, district)
+  endurancetrio_hub.event (id, event_reference, title, start_date, end_date, city, county, district)
 VALUES
   (40, '19890305APT001', '1º Biatlo de Ponte de Sor', '1989-03-05', '1989-03-05', 'Ponte de Sor', 'Ponte de Sor', 'Portalegre'),
   (41, '19890318FPT001', 'Biatlo Jovem Nauticampo', '1989-03-18', '1989-03-18', 'Lisboa', 'Lisboa', 'Lisboa'),
@@ -53,13 +53,13 @@ VALUES
   (65, '19891014FTP001', 'Triatlo da Golegã', '1989-10-14', '1989-10-14', 'Golegã', 'Golegã', 'Santarém'),
   (66, '19891021FTP001', 'Triatlo Cidade de Figueira da Foz', '1989-10-21', '1989-10-21', 'Figueira da Foz', 'Figueira da Foz', 'Coimbra');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_id RESTART WITH 67;
+ALTER SEQUENCE endurancetrio_hub.seq_event_id RESTART WITH 67;
 
 
--- endurancetrio_community.organizer table
+-- endurancetrio_hub.organizer table
 --
 INSERT INTO
-  endurancetrio_community.organizer (id, name, city, county, district, organizer_type)
+  endurancetrio_hub.organizer (id, name, city, county, district, organizer_type)
 VALUES
   (34, 'Federação de Triatlo de Portugal', 'Murganhal', 'Oeiras', 'Lisboa', 'PRIVATE'),
   (35, 'Associação Industrial Portuguesa', 'Lisboa', 'Lisboa', 'Lisboa', 'PRIVATE'),
@@ -77,13 +77,13 @@ VALUES
   (47, 'Câmara Municipal da Golegã', 'Golegã', 'Golegã', 'Santarém', 'PUBLIC'),
   (48, 'Câmara Municipal da Figueira da Foz', 'Figueira da Foz', 'Figueira da Foz', 'Coimbra', 'PUBLIC');
 
-ALTER SEQUENCE endurancetrio_community.seq_organizer_id RESTART WITH 49;
+ALTER SEQUENCE endurancetrio_hub.seq_organizer_id RESTART WITH 49;
 
 
--- endurancetrio_community.event_organizer table
+-- endurancetrio_hub.event_organizer table
 --
 INSERT INTO
-  endurancetrio_community.event_organizer (event_id, organizer_id)
+  endurancetrio_hub.event_organizer (event_id, organizer_id)
 VALUES
   (40, 16),
   (40, 12),
@@ -131,10 +131,10 @@ VALUES
   (66, 48);
 
 
--- endurancetrio_community.event_file table
+-- endurancetrio_hub.event_file table
 --
 INSERT INTO
-  endurancetrio_community.event_file (id, event_id, title, revision, is_active, file_name, file_type)
+  endurancetrio_hub.event_file (id, event_id, title, revision, is_active, file_name, file_type)
 VALUES
   (78, 40, 'Regulamento', 1, true, '19890305APT001-REG001-01.pdf', 'RULES'),
   (79, 40, 'Percursos', 1, true, '19890305APT001-MAP001-01.pdf', 'COURSE_MAPS'),
@@ -163,13 +163,13 @@ VALUES
   (102, 66, 'Regulamento', 1, true, '19891021FTP001-REG001-01.pdf', 'RULES'),
   (103, 66, 'Percursos', 1, true, '19891021FTP001-MAP001-01.pdf', 'COURSE_MAPS');
 
-ALTER SEQUENCE endurancetrio_community.seq_event_file_id RESTART WITH 104;
+ALTER SEQUENCE endurancetrio_hub.seq_event_file_id RESTART WITH 104;
 
 
--- endurancetrio_community.distance table
+-- endurancetrio_hub.distance table
 --
 INSERT INTO
-  endurancetrio_community.distance (id, distance_type)
+  endurancetrio_hub.distance (id, distance_type)
 VALUES
   (41, 'SPRINT'),
   (42, 'YOUTH'),
@@ -200,13 +200,13 @@ VALUES
   (67, 'STANDARD'),
   (68, 'STANDARD');
 
-ALTER SEQUENCE endurancetrio_community.seq_distance_id RESTART WITH 69;
+ALTER SEQUENCE endurancetrio_hub.seq_distance_id RESTART WITH 69;
 
 
--- endurancetrio_community.duathlon_distance table
+-- endurancetrio_hub.duathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.duathlon_distance (id, first_run_distance, first_run_laps, bike_distance, bike_laps, second_run_distance, second_run_laps)
+  endurancetrio_hub.duathlon_distance (id, first_run_distance, first_run_laps, bike_distance, bike_laps, second_run_distance, second_run_laps)
 VALUES
   (41, 5000, 1, 30000, 1, 5000, 1),
   (42, 1000, 1, 8000, 1, 1000, 1),
@@ -218,10 +218,10 @@ VALUES
   (53, 5000, 1, 42000, 1, 5000, 1);
 
 
--- endurancetrio_community.triathlon_distance table
+-- endurancetrio_hub.triathlon_distance table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
+  endurancetrio_hub.triathlon_distance (id, swim_distance, swim_laps, bike_distance, bike_laps, run_distance, run_laps)
 VALUES
   (48, 600, 1, 36000, 1, 6000, 1),
   (49, 1000, 1, 50000, 1, 10000, 1),
@@ -243,10 +243,10 @@ VALUES
   (68, 1000, 1, 40000, 1, 10000, 1);
 
 
--- endurancetrio_community.course table
+-- endurancetrio_hub.course table
 --
 INSERT INTO
-  endurancetrio_community.course (id, event_id, title, sport, distance_id)
+  endurancetrio_hub.course (id, event_id, title, sport, distance_id)
 VALUES
   (41, 40, 'Duatlo Sprint', 'DUATHLON', 41),
   (42, 41, 'Duatlo Jovem', 'DUATHLON', 42),
@@ -277,13 +277,13 @@ VALUES
   (67, 65, 'Triatlo de Promoção', 'TRIATHLON', null),
   (68, 66, 'Triatlo Standard', 'TRIATHLON', 68);
 
-ALTER SEQUENCE endurancetrio_community.seq_course_id RESTART WITH 69;
+ALTER SEQUENCE endurancetrio_hub.seq_course_id RESTART WITH 69;
 
 
--- endurancetrio_community.race table
+-- endurancetrio_hub.race table
 --
 INSERT INTO
-  endurancetrio_community.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
+  endurancetrio_hub.race (id, race_reference, title, subtitle, gender_category, age_group_id, race_type, race_date, race_time, gun_time, air_temperature, race_status)
 VALUES
   (164, '19890305APT001-001', '1º Biatlo de Ponte de Sor', 'Geral', 'OPEN', 1, 'INDIVIDUAL_PARENT', '1989-03-05', '14:00:00', null, null, 'COMPLETED'),
   (165, '19890305APT001-002', '1º Biatlo de Ponte de Sor', 'Femininos', 'FEMALE', 1, 'INDIVIDUAL_DERIVED', '1989-03-05', '14:00:00', null, null, 'COMPLETED'),
@@ -418,13 +418,13 @@ VALUES
   (294, '19891021FTP001-004', 'Triatlo Cidade de Figueira da Foz', 'Equipas femininas', 'FEMALE', 1, 'TEAM_BY_TIME', '1989-10-21', '10:00:00', null, null, 'PLANNED'),
   (295, '19891021FTP001-005', 'Triatlo Cidade de Figueira da Foz', 'Equipas masculinas', 'MALE', 1, 'TEAM_BY_TIME', '1989-10-21', '10:00:00', null, null, 'COMPLETED');
 
-ALTER SEQUENCE endurancetrio_community.seq_race_id RESTART WITH 296;
+ALTER SEQUENCE endurancetrio_hub.seq_race_id RESTART WITH 296;
 
 
--- endurancetrio_community.triathlon_based_race table
+-- endurancetrio_hub.triathlon_based_race table
 --
 INSERT INTO
-  endurancetrio_community.triathlon_based_race (id, water_temperature, wetsuit_rule)
+  endurancetrio_hub.triathlon_based_race (id, water_temperature, wetsuit_rule)
 VALUES
   (197, null, 'UNKNOWN'),
   (198, null, 'UNKNOWN'),
@@ -522,10 +522,10 @@ VALUES
   (295, null, 'UNKNOWN');
 
 
--- endurancetrio_community.course_race table
+-- endurancetrio_hub.course_race table
 --
 INSERT INTO
-  endurancetrio_community.course_race (course_id, race_id)
+  endurancetrio_hub.course_race (course_id, race_id)
 VALUES
   (41, 164),
   (41, 165),
@@ -658,10 +658,10 @@ VALUES
   (68, 295);
 
 
--- endurancetrio_community.race_hierarchy table
+-- endurancetrio_hub.race_hierarchy table
 --
 INSERT INTO
-  endurancetrio_community.race_hierarchy (race_id, parent_race_id)
+  endurancetrio_hub.race_hierarchy (race_id, parent_race_id)
 VALUES
   (165, 164),
   (166, 164),
@@ -769,10 +769,10 @@ VALUES
   (295, 293);
 
 
--- endurancetrio_community.results_file table
+-- endurancetrio_hub.results_file table
 --
 INSERT INTO
-  endurancetrio_community.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
+  endurancetrio_hub.results_file (id, race_id, title, subtitle, revision, is_active, file_name)
 VALUES
   (59, 164, '1º Biatlo de Ponte de Sor', 'Geral', 1, true, '19890305APT001-001A-01.pdf'),
   (60, 166, '1º Biatlo de Ponte de Sor', 'Escalões Masculinos', 1, true, '19890305APT001-003B-01.pdf'),
@@ -830,4 +830,4 @@ VALUES
   (112, 288, 'Triatlo da Golegã', 'Geral', 1, true, '19891014FTP001-001A-01.pdf'),
   (113, 291, 'I Triatlo da Figueira da Foz', 'Geral', 1, true, '19891021FTP001-001A-01.pdf');
 
-ALTER SEQUENCE endurancetrio_community.seq_results_file_id RESTART WITH 114;
+ALTER SEQUENCE endurancetrio_hub.seq_results_file_id RESTART WITH 114;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.008__insert-test-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.000.001.008__insert-test-data-h2.sql
@@ -23,13 +23,13 @@
 
 -- Insert test data into tracker_account table
 INSERT INTO
-  endurancetrio_community.tracker_account (owner, account_key, enabled, version, created_at)
+  endurancetrio_hub.tracker_account (owner, account_key, enabled, version, created_at)
 VALUES
   ('system', 'TEST_ACCOUNT_KEY_1234567890', TRUE, 0, CURRENT_TIMESTAMP);
 
 -- Insert test data into tracking_data table
 INSERT INTO
-  endurancetrio_community.tracking_data (id, account, device, record_time, latitude, longitude, active, version, created_at)
+  endurancetrio_hub.tracking_data (id, account, device, record_time, latitude, longitude, active, version, created_at)
 VALUES
   (1, 'system', 'SDABC', '2025-09-21T06:00:00Z', 39.510058, -9.136079, TRUE, 0, CURRENT_TIMESTAMP),
   (2, 'system', 'SDDEF', '2025-09-21T06:00:06Z', 39.509001, -9.139602, TRUE, 0, CURRENT_TIMESTAMP),
@@ -41,4 +41,4 @@ VALUES
 
 -- Align the sequence to take in consideration manually inserted records
 -- The next sequence value will be 100, which will help to distinguish the test values
-ALTER SEQUENCE endurancetrio_community.seq_tracking_data_id RESTART WITH 100;
+ALTER SEQUENCE endurancetrio_hub.seq_tracking_data_id RESTART WITH 100;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.002.000.002__insert-telemetry-management-test-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.002.000.002__insert-telemetry-management-test-data-h2.sql
@@ -23,7 +23,7 @@
 
 -- Insert test data into device_telemetry table
 INSERT INTO
-  endurancetrio_community.device_telemetry (id, account, device, record_time, latitude, longitude, active, version, created_at)
+  endurancetrio_hub.device_telemetry (id, account, device, record_time, latitude, longitude, active, version, created_at)
 VALUES
   (1, 'system', 'SDABC', '2025-09-21T06:00:00Z', 39.510058, -9.136079, TRUE, 0, CURRENT_TIMESTAMP),
   (2, 'system', 'SDDEF', '2025-09-21T06:00:06Z', 39.509001, -9.139602, TRUE, 0, CURRENT_TIMESTAMP),
@@ -35,4 +35,4 @@ VALUES
 
 -- Align the sequence to take in consideration manually inserted records
 -- The next sequence value will be 100, which will help to distinguish the test values
-ALTER SEQUENCE endurancetrio_community.seq_device_telemetry_id RESTART WITH 100;
+ALTER SEQUENCE endurancetrio_hub.seq_device_telemetry_id RESTART WITH 100;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.002.000.004__insert-route-test-data-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V000.002.000.004__insert-route-test-data-h2.sql
@@ -23,17 +23,17 @@
 
 -- Insert test data into route table
 INSERT INTO
-  endurancetrio_community.route (id, reference, created_at)
+  endurancetrio_hub.route (id, reference, created_at)
 VALUES
   (1, '20260921ETU001-001S', CURRENT_TIMESTAMP);
 
 -- Align the sequence to take in consideration manually inserted records
 -- The next sequence value will be 100, which will help to distinguish the test values
-ALTER SEQUENCE endurancetrio_community.seq_route_id RESTART WITH 100;
+ALTER SEQUENCE endurancetrio_hub.seq_route_id RESTART WITH 100;
 
 -- Insert test data into route_segment table
 INSERT INTO
-  endurancetrio_community.route_segment (id, route_id, segment_order, start_device, end_device, created_at)
+  endurancetrio_hub.route_segment (id, route_id, segment_order, start_device, end_device, created_at)
 VALUES
   (1, 1, 1, 'SDABC', 'SDDEF', CURRENT_TIMESTAMP),
   (2, 1, 2, 'SDDEF', 'SDFGH', CURRENT_TIMESTAMP),
@@ -41,4 +41,4 @@ VALUES
 
 -- Align the sequence to take in consideration manually inserted records
 -- The next sequence value will be 100, which will help to distinguish the test values
-ALTER SEQUENCE endurancetrio_community.seq_route_segment_id RESTART WITH 100;
+ALTER SEQUENCE endurancetrio_hub.seq_route_segment_id RESTART WITH 100;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260607.001__fix-1988-1989-biatlo-course-types-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260607.001__fix-1988-1989-biatlo-course-types-h2.sql
@@ -22,7 +22,7 @@
 -- in 1988 and 1989, and corrects course titles from "Duatlo" to "Biatlo"
 
 UPDATE
-  endurancetrio_community.course
+  endurancetrio_hub.course
 SET
   sport = 'BIATHLON',
   title = CASE id

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.001__swap-course-ids-course-race-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.001__swap-course-ids-course-race-h2.sql
@@ -1,6 +1,26 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Swaps course_id values 6 and 7 to 7 and 8 respectively in the
 -- course_race junction table. Order is important: 7→8 first to free course_id 7,
 -- then 6→7. Course 8 has no existing course_race entries so no PK conflicts arise.
 
-UPDATE endurancetrio_community.course_race SET course_id = 8 WHERE course_id = 7;
-UPDATE endurancetrio_community.course_race SET course_id = 7 WHERE course_id = 6;
+UPDATE endurancetrio_hub.course_race SET course_id = 8 WHERE course_id = 7;
+UPDATE endurancetrio_hub.course_race SET course_id = 7 WHERE course_id = 6;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.002__revert-1988-1989-biatlo-course-types-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.002__revert-1988-1989-biatlo-course-types-h2.sql
@@ -1,8 +1,28 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Reverts courses incorrectly changed from DUATHLON to BIATHLON
 -- for the 1988/1989 biatlo events, restoring original sport and titles.
 
 UPDATE
-  endurancetrio_community.course
+  endurancetrio_hub.course
 SET
   sport = 'DUATHLON',
   title = CASE id

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.003__move-race-148-to-course-37-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.003__move-race-148-to-course-37-h2.sql
@@ -1,4 +1,24 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Moves race 148 (V Triatlo de Peniche, Equipas masculinas) from
 -- course 38 to course 37 (Triatlo Standard), correcting the course assignment.
 
-UPDATE endurancetrio_community.course_race SET course_id = 37 WHERE race_id = 148;
+UPDATE endurancetrio_hub.course_race SET course_id = 37 WHERE race_id = 148;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.004__fix-event-organizers-h2.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/h2/V20260610.004__fix-event-organizers-h2.sql
@@ -1,6 +1,26 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Corrects organizer assignments for events 53 and 54.
 -- Event 53 (Triatlo de Almodôvar): organizer 37 -> 34
 -- Event 54 (Triatlo de Coimbra): organizer 37 -> 40
 
-UPDATE endurancetrio_community.event_organizer SET organizer_id = 40 WHERE event_id = 54;
-UPDATE endurancetrio_community.event_organizer SET organizer_id = 34 WHERE event_id = 53 AND organizer_id = 37;
+UPDATE endurancetrio_hub.event_organizer SET organizer_id = 40 WHERE event_id = 54;
+UPDATE endurancetrio_hub.event_organizer SET organizer_id = 34 WHERE event_id = 53 AND organizer_id = 37;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.002__insert-1984-portuguese-triathlon-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.002__insert-1984-portuguese-triathlon-data-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Inserts the data of the 1984 triathlon related events in Portugal
 --
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- event table
 --

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.003__insert-1985-portuguese-triathlon-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.003__insert-1985-portuguese-triathlon-data-postgres.sql
@@ -20,8 +20,8 @@
 
 -- Description: Inserts the data of the 1985 triathlon related events in Portugal
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- event table
 --

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.004__insert-1986-portuguese-triathlon-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.004__insert-1986-portuguese-triathlon-data-postgres.sql
@@ -20,8 +20,8 @@
 
 -- Description: Inserts the data of the 1986 triathlon related events in Portugal
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- event table
 --

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.005__insert-1987-portuguese-triathlon-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.005__insert-1987-portuguese-triathlon-data-postgres.sql
@@ -20,8 +20,8 @@
 
 -- Description: Inserts the data of the 1987 triathlon related events in Portugal
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- event table
 --

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.006__insert-1988-portuguese-triathlon-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.006__insert-1988-portuguese-triathlon-data-postgres.sql
@@ -20,8 +20,8 @@
 
 -- Description: Inserts the data of the 1988 triathlon related events in Portugal
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- event table
 --

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.007__insert-1989-portuguese-triathlon-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.007__insert-1989-portuguese-triathlon-data-postgres.sql
@@ -20,8 +20,8 @@
 
 -- Description: Inserts the data of the 1989 triathlon related events in Portugal
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- event table
 --

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.008__insert-test-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.000.001.008__insert-test-data-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Inserts test data into EnduranceTrio application database tables
 --
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- Insert test data into tracker_account table
 INSERT INTO

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.002.000.002__insert-telemetry-management-test-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.002.000.002__insert-telemetry-management-test-data-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Inserts test data into EnduranceTrio telemetry management database table
 --
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- Insert test data into device_telemetry table
 INSERT INTO

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.002.000.004__insert-route-test-data-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V000.002.000.004__insert-route-test-data-postgres.sql
@@ -21,8 +21,8 @@
 -- Description: Inserts Tracker test data into EnduranceTrio application route database tables
 --
 
--- Set the search path to the schema `endurancetrio_community`
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 -- Insert test data into route table
 INSERT INTO

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260607.001__fix-1988-1989-biatlo-course-types-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260607.001__fix-1988-1989-biatlo-course-types-postgres.sql
@@ -21,7 +21,7 @@
 -- Description: Fixes course sport from DUATHLON to BIATHLON for biatlo events inserted
 -- in 1988 and 1989, and corrects course titles from "Duatlo" to "Biatlo"
 
-SET search_path TO endurancetrio_community;
+SET search_path TO endurancetrio_hub;
 
 UPDATE
   course

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.001__swap-course-ids-course-race-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.001__swap-course-ids-course-race-postgres.sql
@@ -1,8 +1,29 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Swaps course_id values 6 and 7 to 7 and 8 respectively in the
 -- course_race junction table. Order is important: 7→8 first to free course_id 7,
 -- then 6→7. Course 8 has no existing course_race entries so no PK conflicts arise.
 
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 UPDATE course_race SET course_id = 8 WHERE course_id = 7;
 UPDATE course_race SET course_id = 7 WHERE course_id = 6;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.002__revert-1988-1989-biatlo-course-types-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.002__revert-1988-1989-biatlo-course-types-postgres.sql
@@ -1,7 +1,28 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Reverts courses incorrectly changed from DUATHLON to BIATHLON
 -- for the 1988/1989 biatlo events, restoring original sport and titles.
 
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 UPDATE
   course

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.003__move-race-148-to-course-37-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.003__move-race-148-to-course-37-postgres.sql
@@ -1,6 +1,27 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Moves race 148 (V Triatlo de Peniche, Equipas masculinas) from
 -- course 38 to course 37 (Triatlo Standard), correcting the course assignment.
 
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 UPDATE course_race SET course_id = 37 WHERE race_id = 148;

--- a/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.004__fix-event-organizers-postgres.sql
+++ b/endurancetrio-data/src/main/resources/db/migration/dml/postgres/V20260610.004__fix-event-organizers-postgres.sql
@@ -1,8 +1,29 @@
+--
+-- Copyright (c) 2011-2026 Ricardo do Canto
+--
+-- This file is part of the EnduranceTrio project.
+--
+-- Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+-- (the "License");
+--
+-- You may not use this file except in compliance with the License. You may obtain a copy
+-- of the License at https://fsl.software/
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+-- PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+--
+-- IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+-- SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+-- EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+--
+
 -- Description: Corrects organizer assignments for events 53 and 54.
 -- Event 53 (Triatlo de Almodôvar): organizer 37 -> 34
 -- Event 54 (Triatlo de Coimbra): organizer 37 -> 40
 
-SET search_path TO endurancetrio_community;
+-- Set the search path to the schema `endurancetrio_hub`
+SET search_path TO endurancetrio_hub;
 
 UPDATE event_organizer SET organizer_id = 40 WHERE event_id = 54;
 UPDATE event_organizer SET organizer_id = 34 WHERE event_id = 53 AND organizer_id = 37;

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/AgeGroupTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/AgeGroupTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link AgeGroup} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class AgeGroupTest {
+
+  AgeGroup underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new AgeGroup();
+    underTest.setId(1L);
+    underTest.setCode("BEN");
+    underTest.setDenominationEN("Benjamin");
+    underTest.setDenominationPT("Benjamin");
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+    assertEquals(1L, underTest.getId());
+    assertEquals("BEN", underTest.getCode());
+    assertEquals("Benjamin", underTest.getDenominationEN());
+    assertEquals("Benjamin", underTest.getDenominationPT());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/AthleteTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/AthleteTest.java
@@ -18,36 +18,37 @@
  * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
  */
 
-package com.endurancetrio.data.event.model.entity;
+package com.endurancetrio.data.competitor.model.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.endurancetrio.data.competitor.model.enumerator.AthleteGender;
+import com.endurancetrio.data.competitor.model.enumerator.Country;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Unit test for the {@link AgeGroupTest} entity.
- * <p>
- * This test may seem redundant since it only verify getters and setters, but its purpose is to
- * establish a testing culture from the very beginning of the project. It serves as a reminder that
- * every part of the application should be testable and that tests should always be present.
- */
-class AgeGroupTest {
+class AthleteTest {
 
-  AgeGroup underTest;
+  private Athlete underTest;
 
   @BeforeEach
   void setUp() {
-    underTest = new AgeGroup();
+    underTest = new Athlete();
     underTest.setId(1L);
-    underTest.setTitle("Benjamins");
-    underTest.setShortTitle("BEN");
+    underTest.setFullName("Paulo Paula Carvalho");
+    underTest.setKnownName("Paulo Carvalho");
+    underTest.setGender(AthleteGender.MALE);
+    underTest.setCountry(Country.POR);
+    underTest.setYearOfBirth(1961);
   }
 
   @Test
   void entityShouldRetainValues() {
     assertEquals(1L, underTest.getId());
-    assertEquals("Benjamins", underTest.getTitle());
-    assertEquals("BEN", underTest.getShortTitle());
+    assertEquals("Paulo Paula Carvalho", underTest.getFullName());
+    assertEquals("Paulo Carvalho", underTest.getKnownName());
+    assertEquals(AthleteGender.MALE, underTest.getGender());
+    assertEquals(Country.POR, underTest.getCountry());
+    assertEquals(1961, underTest.getYearOfBirth());
   }
 }

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/ParaClassTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/ParaClassTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link ParaClass} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class ParaClassTest {
+
+  private ParaClass underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new ParaClass();
+    underTest.setId(1L);
+    underTest.setCode("PTVI");
+    underTest.setDenominationEN("Vision Impaired");
+    underTest.setDenominationPT("Deficiência Visual");
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+    assertEquals(1L, underTest.getId());
+    assertEquals("PTVI", underTest.getCode());
+    assertEquals("Vision Impaired", underTest.getDenominationEN());
+    assertEquals("Deficiência Visual", underTest.getDenominationPT());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/TeamTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/entity/TeamTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link Team} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class TeamTest {
+
+  private Team underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new Team();
+    underTest.setId(1L);
+    underTest.setFullName("Sport Clube");
+    underTest.setShortName("SC");
+    underTest.setCity("Lisbon");
+    underTest.setCounty("Lisbon");
+    underTest.setDistrict("Lisbon");
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+    assertEquals(1L, underTest.getId());
+    assertEquals("Sport Clube", underTest.getFullName());
+    assertEquals("SC", underTest.getShortName());
+    assertEquals("Lisbon", underTest.getCity());
+    assertEquals("Lisbon", underTest.getCounty());
+    assertEquals("Lisbon", underTest.getDistrict());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/DurationToIntegerConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/DurationToIntegerConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link DurationToIntegerConverter} converter.
+ */
+class DurationToIntegerConverterTest {
+
+  private DurationToIntegerConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new DurationToIntegerConverter();
+  }
+
+  @Test
+  void shouldConvertDurationToDatabaseColumn() {
+    Duration duration = Duration.ofMinutes(90);
+    Integer expected = 5_400_000;
+
+    assertEquals(expected, underTest.convertToDatabaseColumn(duration));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullDurationToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertMillisecondsToDuration() {
+    Integer milliseconds = 5_400_000;
+    Duration expected = Duration.ofMinutes(90);
+
+    assertEquals(expected, underTest.convertToEntityAttribute(milliseconds));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullMillisecondsToDuration() {
+    assertNull(underTest.convertToEntityAttribute(null));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/PenaltyConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/PenaltyConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.Penalty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link PenaltyConverter} converter.
+ */
+class PenaltyConverterTest {
+
+  private PenaltyConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new PenaltyConverter();
+  }
+
+  @Test
+  void shouldConvertPenaltyToDatabaseColumn() {
+    assertEquals("DNF", underTest.convertToDatabaseColumn(Penalty.DNF));
+    assertEquals("DSQ", underTest.convertToDatabaseColumn(Penalty.DSQ));
+    assertEquals("DNS", underTest.convertToDatabaseColumn(Penalty.DNS));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullPenaltyToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToPenalty() {
+    assertEquals(Penalty.DNF, underTest.convertToEntityAttribute("DNF"));
+    assertEquals(Penalty.DSQ, underTest.convertToEntityAttribute("DSQ"));
+    assertEquals(Penalty.DNS, underTest.convertToEntityAttribute("DNS"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/CourseTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/CourseTest.java
@@ -22,12 +22,6 @@ package com.endurancetrio.data.event.model.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.endurancetrio.data.event.model.entity.AgeGroup;
-import com.endurancetrio.data.event.model.entity.Course;
-import com.endurancetrio.data.event.model.entity.DuathlonDistance;
-import com.endurancetrio.data.event.model.entity.Event;
-import com.endurancetrio.data.event.model.entity.Race;
-import com.endurancetrio.data.event.model.entity.ResultsFile;
 import com.endurancetrio.data.event.model.enumerator.DistanceType;
 import com.endurancetrio.data.event.model.enumerator.GenderCategory;
 import com.endurancetrio.data.event.model.enumerator.RaceStatus;
@@ -70,11 +64,6 @@ class CourseTest {
     testDistance.setSecondRunDistance(180);
     testDistance.setSecondRunLaps(1);
 
-    AgeGroup testAgeGroup = new AgeGroup();
-    testAgeGroup.setId(1L);
-    testAgeGroup.setTitle("Benjamins");
-    testAgeGroup.setShortTitle("BEN");
-
     ResultsFile testResultsFile = new ResultsFile();
     testResultsFile.setId(1L);
 
@@ -86,7 +75,6 @@ class CourseTest {
     testRace.setTitle("XVI Duatlo Jovem de Grândola");
     testRace.setSubtitle("Benjamins Masculinos");
     testRace.setGenderCategory(GenderCategory.MALE);
-    testRace.setAgeGroup(testAgeGroup);
     testRace.setDate(LocalDate.parse("2010-03-06"));
     testRace.setTime(LocalTime.parse("14:30:00"));
     testRace.setRaceStatus(RaceStatus.COMPLETED);

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/IndividualResultTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/IndividualResultTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link IndividualResult} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class IndividualResultTest {
+
+  private IndividualResult underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new IndividualResult();
+    underTest.setId(1L);
+    underTest.setRank(1);
+    underTest.setTeamName("Individual");
+    underTest.setBib("101");
+    underTest.setSwim(Duration.ofMinutes(20));
+    underTest.setBike(Duration.ofMinutes(60));
+    underTest.setRun(Duration.ofMinutes(30));
+    underTest.setTotal(Duration.ofMinutes(110));
+    underTest.setPoints(1000);
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+    assertEquals(1L, underTest.getId());
+    assertEquals(1, underTest.getRank());
+    assertNull(underTest.getRace());
+    assertNull(underTest.getSourceResult());
+    assertNull(underTest.getPenalty());
+    assertNull(underTest.getAthlete());
+    assertNull(underTest.getTeam());
+    assertEquals("Individual", underTest.getTeamName());
+    assertNull(underTest.getAgeGroup());
+    assertNull(underTest.getParaClass());
+    assertEquals("101", underTest.getBib());
+    assertEquals(Duration.ofMinutes(20), underTest.getSwim());
+    assertNull(underTest.getFirstBike());
+    assertNull(underTest.getFirstRun());
+    assertNull(underTest.getT1());
+    assertEquals(Duration.ofMinutes(60), underTest.getBike());
+    assertNull(underTest.getT2());
+    assertEquals(Duration.ofMinutes(30), underTest.getRun());
+    assertNull(underTest.getSecondRun());
+    assertNull(underTest.getT3());
+    assertNull(underTest.getSecondBike());
+    assertEquals(Duration.ofMinutes(110), underTest.getTotal());
+    assertEquals(1000, underTest.getPoints());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/RaceTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/RaceTest.java
@@ -23,10 +23,6 @@ package com.endurancetrio.data.event.model.entity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.endurancetrio.data.event.model.entity.AgeGroup;
-import com.endurancetrio.data.event.model.entity.Course;
-import com.endurancetrio.data.event.model.entity.Race;
-import com.endurancetrio.data.event.model.entity.ResultsFile;
 import com.endurancetrio.data.event.model.enumerator.GenderCategory;
 import com.endurancetrio.data.event.model.enumerator.RaceStatus;
 import com.endurancetrio.data.event.model.enumerator.RaceType;
@@ -48,18 +44,12 @@ class RaceTest {
   private Race underTest;
 
   private Course testCourse;
-  private AgeGroup testAgeGroup;
   private ResultsFile testResultsFile;
 
   @BeforeEach
   void setUp() {
     testCourse = new Course();
     testCourse.setId(1L);
-
-    testAgeGroup = new AgeGroup();
-    testAgeGroup.setId(1L);
-    testAgeGroup.setTitle("Benjamins");
-    testAgeGroup.setShortTitle("BEN");
 
     ResultsFile testParentResultFile = new ResultsFile();
     testParentResultFile.setId(1L);
@@ -75,7 +65,6 @@ class RaceTest {
     testParentRace.setTitle("XVI Duatlo Jovem de Grândola");
     testParentRace.setSubtitle("Benjamins Geral");
     testParentRace.setGenderCategory(GenderCategory.OPEN);
-    testParentRace.setAgeGroup(testAgeGroup);
     testParentRace.setDate(LocalDate.parse("2010-03-06"));
     testParentRace.setTime(LocalTime.parse("14:30:00"));
     testParentRace.setRaceStatus(RaceStatus.COMPLETED);
@@ -92,7 +81,6 @@ class RaceTest {
     underTest.setTitle("XVI Duatlo Jovem de Grândola");
     underTest.setSubtitle("Benjamins Masculinos");
     underTest.setGenderCategory(GenderCategory.MALE);
-    underTest.setAgeGroup(testAgeGroup);
     underTest.setDate(LocalDate.parse("2010-03-06"));
     underTest.setTime(LocalTime.parse("14:30:00"));
     underTest.setRaceStatus(RaceStatus.COMPLETED);
@@ -113,8 +101,6 @@ class RaceTest {
     assertEquals("XVI Duatlo Jovem de Grândola", underTest.getTitle());
     assertEquals("Benjamins Masculinos", underTest.getSubtitle());
     assertEquals(GenderCategory.MALE, underTest.getGenderCategory());
-    assertNotNull(underTest.getAgeGroup());
-    assertEquals(testAgeGroup.getShortTitle(), underTest.getAgeGroup().getShortTitle());
     assertEquals(LocalDate.parse("2010-03-06"), underTest.getDate());
     assertEquals(LocalTime.parse("14:30:00"), underTest.getTime());
     assertEquals(RaceStatus.COMPLETED, underTest.getRaceStatus());

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/TeamResultTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/TeamResultTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link TeamResult} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class TeamResultTest {
+
+  private TeamResult underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new TeamResult();
+    underTest.setId(1L);
+    underTest.setRank(1);
+    underTest.setTeamName("Sport Clube");
+    underTest.setAthletesCount(3);
+    underTest.setBib("T01");
+    underTest.setCumulativeRank(10);
+    underTest.setTotal(Duration.ofMinutes(330));
+    underTest.setPoints(3000);
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+    assertEquals(1L, underTest.getId());
+    assertEquals(1, underTest.getRank());
+    assertNull(underTest.getRace());
+    assertNull(underTest.getSourceResult());
+    assertNull(underTest.getPenalty());
+    assertNull(underTest.getTeam());
+    assertEquals("Sport Clube", underTest.getTeamName());
+    assertEquals(3, underTest.getAthletesCount());
+    assertTrue(underTest.getIndividualResults().isEmpty());
+    assertNull(underTest.getAgeGroup());
+    assertNull(underTest.getParaClass());
+    assertEquals("T01", underTest.getBib());
+    assertEquals(Integer.valueOf(10), underTest.getCumulativeRank());
+    assertEquals(Duration.ofMinutes(330), underTest.getTotal());
+    assertEquals(3000, underTest.getPoints());
+  }
+
+  @Test
+  void addIndividualResultShouldAddIndividualResult() {
+    IndividualResult individualResult = new IndividualResult();
+    individualResult.setId(100L);
+
+    underTest.addIndividualResult(individualResult);
+
+    assertEquals(1, underTest.getIndividualResults().size());
+    assertTrue(underTest.getIndividualResults().contains(individualResult));
+  }
+
+  @Test
+  void addIndividualResultShouldIgnoreNull() {
+    underTest.addIndividualResult(null);
+
+    assertTrue(underTest.getIndividualResults().isEmpty());
+  }
+
+  @Test
+  void removeIndividualResultShouldRemoveIndividualResult() {
+    IndividualResult individualResult = new IndividualResult();
+    individualResult.setId(100L);
+    underTest.getIndividualResults().add(individualResult);
+
+    underTest.removeIndividualResult(individualResult);
+
+    assertTrue(underTest.getIndividualResults().isEmpty());
+  }
+
+  @Test
+  void removeIndividualResultShouldIgnoreNull() {
+    IndividualResult individualResult = new IndividualResult();
+    individualResult.setId(100L);
+    underTest.getIndividualResults().add(individualResult);
+
+    underTest.removeIndividualResult(null);
+
+    assertFalse(underTest.getIndividualResults().isEmpty());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/TriathlonBasedRaceTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/entity/TriathlonBasedRaceTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit test for the {@link TriathlonBasedRaceTest} entity.
+ * Unit test for the {@link TriathlonBasedRace} entity.
  * <p>
  * This test may seem redundant since it only verify getters and setters, but its purpose is to
  * establish a testing culture from the very beginning of the project. It serves as a reminder that
@@ -46,18 +46,12 @@ class TriathlonBasedRaceTest {
   private TriathlonBasedRace underTest;
 
   private Course testCourse;
-  private AgeGroup testAgeGroup;
   private ResultsFile testResultsFile;
 
   @BeforeEach
   void setUp() {
     testCourse = new Course();
     testCourse.setId(1L);
-
-    testAgeGroup = new AgeGroup();
-    testAgeGroup.setId(1L);
-    testAgeGroup.setTitle("Geral");
-    testAgeGroup.setShortTitle("OVERALL");
 
     testResultsFile = new ResultsFile();
     testResultsFile.setId(1L);
@@ -70,7 +64,6 @@ class TriathlonBasedRaceTest {
     underTest.setTitle("Triatlo de Peniche");
     underTest.setSubtitle("Geral");
     underTest.setGenderCategory(GenderCategory.OPEN);
-    underTest.setAgeGroup(testAgeGroup);
     underTest.setDate(LocalDate.parse("1984-08-15"));
     underTest.setTime(LocalTime.parse("16:00:00"));
     underTest.setRaceStatus(RaceStatus.COMPLETED);
@@ -92,8 +85,6 @@ class TriathlonBasedRaceTest {
     assertEquals("Triatlo de Peniche", underTest.getTitle());
     assertEquals("Geral", underTest.getSubtitle());
     assertEquals(GenderCategory.OPEN, underTest.getGenderCategory());
-    assertNotNull(underTest.getAgeGroup());
-    assertEquals(testAgeGroup.getShortTitle(), underTest.getAgeGroup().getShortTitle());
     assertEquals(LocalDate.parse("1984-08-15"), underTest.getDate());
     assertEquals(LocalTime.parse("16:00:00"), underTest.getTime());
     assertEquals(RaceStatus.COMPLETED, underTest.getRaceStatus());

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <sonar.organization>endurancecode</sonar.organization>
+    <sonar.cpd.exclusions>**/db/migration/**/*.sql</sonar.cpd.exclusions>
+    <sonar.exclusions>**/db/migration/**/*.sql</sonar.exclusions>
     <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
     <node.version>v24.15.0</node.version>
     <npm.version>11.12.1</npm.version>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=endurancecode_endurancetrio-community
 sonar.host.url=https://sonarcloud.io
 
 # Path to sources
-#sonar.sources=.
+sonar.sources=.
 sonar.exclusions=**/db/migration/**/*.sql
 #sonar.inclusions=
 


### PR DESCRIPTION
## Description

Introduces the competitor domain (athlete, team, age group, para class) with entities, enums, JPA converters, and tests. Adds `individual_result` and `team_result` tables under the event domain to store race results. Renames the database schema from `endurancetrio_community` to `endurancetrio_hub` to align with the project's naming conventions, and documents the entity layer conventions in the Development Guide.

> **Breaking change:** The Flyway/JPA schema has been renamed from `endurancetrio_community` to `endurancetrio_hub`. Existing databases with the old schema name are incompatible. You must drop all volumes and redeploy from scratch. See the [`init-db.sh`](docker/deployment/scripts/init-db.sh) script for automated database initialization.

### Key changes

- **Competitor domain** — new `Athlete`, `Team`, `AgeGroup`, `ParaClass` entities with corresponding enums (`AthleteGender`, `Country`, `AgeGroup`, `ParaClass`), JPA attribute converters, and entity tests
- **Result data model** — new `IndividualResult` and `TeamResult` entities under the event domain, with converters (`DurationToIntegerConverter`, `PenaltyConverter`) and Flyway DDL/DML migrations for both H2 and PostgreSQL
- **Schema rename** — renamed Flyway/JPA schema from `endurancetrio_community` to `endurancetrio_hub` across all YAML configs and migration files; updated local dev database name to `dev_endurancetrio_community`
- **Documentation** — added entity layer conventions to `docs/development.md` documenting base classes, table/column naming, and migration patterns

## Type of Change


- [x] Breaking change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / code cleanup
- [ ] Build / tooling / CI
- [x] Documentation
- [ ] Translation / language

## How Has This Been Tested

Full Maven build (`./mvnw clean install`) — BUILD SUCCESS. Java 21 (Temurin), Linux.

## Checklist


- [x] My code follows the project's code style and conventions (see `docs/development.md#code--naming-conventions` and `AGENTS.md#key-conventions`)
- [x] The build runs successfully (`./mvnw clean install`)
- [x] I have updated the documentation (`AGENTS.md`, `README.md`, `docs/`, `DATABASE.md`, etc.) if needed
- [x] The commit messages follow the project's convention (50-char subject, 72-char body wrap)