### PR TITLE
Integrate Tracker v0.4.2

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,5 @@
+# Exclusions from analysis (Automatic Analysis)
+sonar.exclusions=**/db/migration/**/*.sql
+
+# Exclusions for copy-paste detection (Automatic Analysis)
+sonar.cpd.exclusions=**/db/migration/**/*.sql

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,20 @@ Entrypoint: `com.endurancetrio.app.EnduranceTrioApplication` (port 8080, Thymele
 - Service pattern: `interface ThingService` → `class ThingServiceMain` (not `Impl`)
 - Method order in services: CRUD (CREATE → READ → UPDATE → DELETE → UTILITY), then alphabetical
 - Entity base classes: `BaseEntity<T>` (id, equals, hashCode), `AuditableEntity` (version, createdAt, updatedAt)
-- Flyway: `V{major}.{minor}.{patch}.{order}__description.sql` in `endurancetrio-data/src/main/resources/db/migration/{ddl,dml}/{h2,postgres}/`
+- Flyway: `V<yyyymmdd>.<seq>__description.sql` in `endurancetrio-data/src/main/resources/db/migration/{ddl,dml}/{h2,postgres}/`
 - DB naming: snake_case, plural tables, constraint prefixes (`pk_`, `fk_`, `uk_`, `chk_`, `idx_`, `seq_`)
 - Historical reference entities: `AgeGroup` and `ParaClass` under `competitor.model.entity` exist solely to document their database table schemas for historical data storage. They are NOT used in application code. The active counterparts are the enums in `competitor.model.enumerator`, stored as VARCHAR columns in result tables.
 - Config files (`*.yaml`, `*.properties`): keys ordered alphabetically (root-level and nested). See [`docs/development.md`](docs/development.md#configuration-file-key-ordering)
+- Javadoc HTML: must use valid HTML — no self-closing tags (e.g., `<a href="..." />`), no stray closing tags. Verify with `mvn javadoc:aggregate`
+
+## Testing
+
+- Tests use H2 in PostgreSQL compatibility mode (`jdbc:h2:mem:endurancetrio_tracker;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE`)
+- Test config: `endurancetrio-app/src/test/resources/application-test.yaml`
+- Business tests use `@ExtendWith(MockitoExtension.class)` (pure Mockito, no Spring context)
+- Flyway migrations for H2 are in `db/migration/ddl/h2` and `db/migration/dml/h2`
+- Tests do NOT require PostgreSQL — H2 is fully self-contained
+- Full testing conventions documented in [docs/development.md#testing](docs/development.md#testing)
 
 ## Tracker integration (dual-repo)
 
@@ -66,14 +76,14 @@ API keys are bcrypt hashes (cost 12). First account via `FIRST_OWNER` + `FIRST_H
 
 ## Configuration
 
-| File                                | Purpose                                                  |
-|-------------------------------------|----------------------------------------------------------|
-| `application.yaml`                  | defaults (datasource, JPA, Flyway, port 8080)            |
-| `application-{local,dev,prod}.yaml` | profile-specific overrides                               |
-| `application-secrets.yaml`          | credentials (gitignored, from `template-secrets.yaml`)   |
-| `application-test.yaml`             | H2 in-memory DB for tests                                |
-| `sonar-project.properties`          | SonarQube Cloud project key, host, source encoding       |
-| `pom.xml`                           | `<sonar.organization>`, CPD and analysis exclusions       |
+| File                                | Purpose                                                |
+|-------------------------------------|--------------------------------------------------------|
+| `application.yaml`                  | defaults (datasource, JPA, Flyway, port 8080)          |
+| `application-{local,dev,prod}.yaml` | profile-specific overrides                             |
+| `application-secrets.yaml`          | credentials (gitignored, from `template-secrets.yaml`) |
+| `application-test.yaml`             | H2 in-memory DB for tests                              |
+| `sonar-project.properties`          | SonarQube Cloud project key, host, source encoding     |
+| `pom.xml`                           | `<sonar.organization>`, CPD and analysis exclusions    |
 
 Profiles: `local` (localhost PG), `dev`/`prod` (env-var PG), `test` (H2). Activate via `-Dspring.profiles.active=local` or `-Dspring-boot.run.profiles=local`.
 
@@ -86,4 +96,5 @@ Profiles: `local` (localhost PG), `dev`/`prod` (env-var PG), `test` (H2). Activa
 
 ## Commit messages
 
-Subject: ≤50 chars, capitalized, imperative mood, no period. Body optional (72-char wrap, explains what/why vs. how). Follows [cbea.ms/git-commit](https://cbea.ms/git-commit/).
+Subject: ≤50 chars, capitalized, imperative mood, no period. Body optional (72-char wrap, explains
+what/why vs. how). Follows [cbea.ms/git-commit](https://cbea.ms/git-commit/).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Entrypoint: `com.endurancetrio.app.TrackerApplication` (scans `com.endurancetrio
 - Business tests use `@ExtendWith(MockitoExtension.class)` (pure Mockito, no Spring context)
 - Flyway migrations for H2 are in `db/migration/ddl/h2` and `db/migration/dml/h2`
 - Tests do NOT require PostgreSQL — H2 is fully self-contained
+- Full testing conventions documented in [docs/development.md#testing](docs/development.md#testing)
 
 ## API
 
@@ -74,6 +75,7 @@ Entrypoint: `com.endurancetrio.app.TrackerApplication` (scans `com.endurancetrio
 - **Method ordering**: Controllers follow Swagger display order. Services grouped by entity then CRUD (CREATE, READ, UPDATE, DELETE, UTILITY). Private methods after all public, alphabetically.
 - **Flyway naming**: `V<yyyymmdd>.<seq>__description.sql`
 - **DB naming**: snake_case, plural table names, constraints prefixed: `pk_`, `fk_`, `uk_`, `chk_`, `idx_`
+- **Javadoc HTML**: must use valid HTML — no self-closing tags (e.g., `<a href="..." />`), no stray closing tags. Verify with `mvn javadoc:aggregate`
 
 ## Profiles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,6 @@ Entrypoint: `com.endurancetrio.app.TrackerApplication` (scans `com.endurancetrio
 
 ## Commit messages
 
-Subject: Uses a "[TRACKER]" prefix, ≤50 chars, capitalized, imperative mood, no period. Body
+Subject: Use a "[TRACKER]" prefix, ≤50 chars, capitalized, imperative mood, no period. Body
 optional (72-char wrap, explains what/why vs. how).
 Follows [cbea.ms/git-commit](https://cbea.ms/git-commit/).

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,8 @@ an overview of the project, see the [main README.md](../README.md).
 3. [Database](#database)
 4. [Installation](#installation)
 5. [Code & Naming Conventions](#code--naming-conventions)
-6. [Programmatic Version Management](#programmatic-version-management)
+6. [Testing](#testing)
+7. [Programmatic Version Management](#programmatic-version-management)
 
 ## Technology Stack
 
@@ -857,6 +858,452 @@ spring:
 
 > `username` appears before the alphabetically-earlier `password` because they form a credentials
 > pair.
+
+## Testing
+
+This section documents the testing standards, conventions, and practices for the project. All tests
+must comply with these rules.
+
+### Testing Approach
+
+All tests are **pure unit tests** — fast, isolated, and requiring no Spring context. There are three
+categories:
+
+| Category                  | Description                                                            | Framework                    |
+|---------------------------|------------------------------------------------------------------------|------------------------------|
+| **Plain POJO tests**      | Entities, DTOs, responses — verify constructors, accessors, `toString` | JUnit 5 only                 |
+| **Mockito-based tests**   | Services, mappers — mock dependencies to isolate the class under test  | JUnit 5 + Mockito            |
+| **Bean Validation tests** | Custom validation annotations — programmatic `Validator` setup         | JUnit 5 + Jakarta Validation |
+
+No test currently loads a Spring application context (`@SpringBootTest`, `@DataJpaTest`,
+`@WebMvcTest`, etc.). If integration tests are added in the future, they must use the existing
+[test configuration](#test-configuration).
+
+### Test Frameworks & Dependencies
+
+| Dependency                            | Scope                            | Used In Module           |
+|---------------------------------------|----------------------------------|--------------------------|
+| **JUnit 5** (Jupiter)                 | Inherited via Spring Boot parent | All modules              |
+| **Mockito**                           | Inherited via Spring Boot parent | `endurancetrio-business` |
+| `spring-boot-starter-data-jpa-test`   | Test                             | `endurancetrio-data`     |
+| `spring-boot-starter-flyway-test`     | Test                             | `endurancetrio-data`     |
+| `com.h2database:h2`                   | Test                             | `endurancetrio-data`     |
+| `spring-boot-starter-validation-test` | Test                             | `endurancetrio-business` |
+| `spring-boot-starter-actuator-test`   | Test                             | `endurancetrio-app`      |
+| `spring-boot-starter-webmvc-test`     | Test                             | `endurancetrio-app`      |
+| `spring-boot-starter-security-test`   | Test                             | `endurancetrio-app`      |
+
+Module-specific test starters are declared **per module** based on what that module needs to test.
+JUnit 5 and Mockito are inherited from the Spring Boot parent POM via `spring-boot-starter-test`.
+
+### Test Class Naming
+
+All test classes must follow the pattern:
+
+```
+{ClassUnderTest}Test.java
+```
+
+| Test Class                   | Tests Class              |
+|------------------------------|--------------------------|
+| `TrackerAccountTest`         | `TrackerAccount`         |
+| `RouteServiceMainTest`       | `RouteServiceMain`       |
+| `DeviceTelemetryMapperTest`  | `DeviceTelemetryMapper`  |
+| `RouteSegmentsValidatorTest` | `RouteSegmentsValidator` |
+
+Service implementations use the `Main` suffix (not `Impl`), so their tests follow the same naming
+(e.g., `RouteServiceMain` → `RouteServiceMainTest`).
+
+### Test Class Declaration
+
+- Class must be **package-private** (no `public` modifier).
+- No class-level annotation for plain POJO tests.
+- `@ExtendWith(MockitoExtension.class)` must be present on Mockito-based tests.
+- Bean Validation tests use a programmatic `Validator` bootstrap in `@BeforeEach` (no Mockito
+  extension required).
+
+```java
+// Plain POJO test — no annotation
+class TrackerAccountTest { ...
+}
+
+// Mockito test — single annotation
+@ExtendWith(MockitoExtension.class)
+class RouteServiceMainTest { ...
+}
+
+// Bean Validation test — programmatic Validator, no Mockito
+class RouteSegmentsValidatorTest { ...
+}
+```
+
+### Test Structure
+
+#### Field Conventions
+
+- **Constants**: `private static final` fields at the top of the class.
+- **Test fixture objects**: declared as `private` instance fields.
+- **Mock dependencies**: annotated with `@Mock`.
+- **Class under test**: annotated with `@InjectMocks`, field named `underTest`.
+
+```java
+private static final String OWNER = "system";
+private static final Long DEVICE_ID = 12345L;
+
+@Mock
+private RouteMapper routeMapper;
+
+@Mock
+private RouteRepository routeRepository;
+
+@InjectMocks
+private RouteServiceMain underTest;
+```
+
+#### Setup Method
+
+A single `@BeforeEach void setUp()` method must create all test fixtures:
+
+```java
+@BeforeEach
+void setUp() {
+    testAccount = new TrackerAccount(OWNER, KEY, true);
+    var device = new DeviceTelemetry();
+    device.setId(DEVICE_ID);
+    existingDevices = Set.of(device);
+}
+```
+
+#### Test Method Naming
+
+Test methods use `camelCase` describing the scenario:
+
+| Pattern           | Examples                                                                               |
+|-------------------|----------------------------------------------------------------------------------------|
+| POJO/Record tests | `dtoShouldRetainValues`, `entityShouldRetainValues`                                    |
+| Happy path        | `create`, `update`, `findAll`, `findById`, `save`, `validateKey`                       |
+| Error/edge case   | `createWithIdShouldThrow`, `updateWithNonExistingRoute`, `validateKeyWithUnknownOwner` |
+| Empty data        | `findAllWhenNoRoutesExist`, `findMostRecentRecordForEachDeviceWithEmptyData`           |
+| Null safety       | `mapNullDTO`, `mapNullEntity`, `updateEntityWithNullDTO`                               |
+| Validation        | `isValid`, `isValidWithInvalidFirstOrder`                                              |
+
+### Mocking Standards
+
+#### Annotations
+
+- `@Mock` for all dependencies.
+- `@InjectMocks` for the class under test.
+
+```java
+
+@Mock
+private RouteMapper routeMapper;
+
+@Mock
+private RouteRepository routeRepository;
+
+@InjectMocks
+private RouteServiceMain underTest;
+```
+
+#### Stubbing Patterns
+
+| Scenario              | Pattern                                                  |
+|-----------------------|----------------------------------------------------------|
+| Return value          | `when(mock.method(...)).thenReturn(value)`               |
+| Return based on input | `when(mock.method(...)).thenAnswer(invocation -> ...)`   |
+| Void method           | `doAnswer(invocation -> { ... }).when(mock).method(...)` |
+| Argument matchers     | `any()`, `anySet()`, `any(RouteDTO.class)`               |
+| Custom matching       | `argThat(arg -> condition)`                              |
+
+#### Verification
+
+```java
+verify(repository, times(1)).
+
+save(entity);
+
+verify(mapper, never()).
+
+map(any());
+```
+
+#### Private Field Injection
+
+Use `ReflectionTestUtils.setField()` only when the class under test has `@Value`-injected fields
+that would normally be set by Spring:
+
+```java
+ReflectionTestUtils.setField(underTest, "firstOwner",OWNER);
+```
+
+### Assertion Style
+
+The project's tests currently use `org.junit.jupiter.api.Assertions.*` static imports for all
+assertions. JUnit 5 assertions (`assertEquals`, `assertNotNull`, `assertThrows`, etc.) remain the
+default and are preferred for consistency with existing test classes.
+
+Other assertion libraries may be used in new tests at the developer's discretion. Notable options:
+
+- **AssertJ** — fluent API with better diagnostics (e.g., `usingRecursiveComparison` for DTO
+  comparison, collection extraction, no parameter-order ambiguity). Already available on the
+  classpath via `spring-boot-starter-test`.
+- **Hamcrest** — matcher-based, legacy. Not recommended.
+- **Truth** — Google's assertion library. Not recommended.
+
+| Assertion                                  | Usage                     |
+|--------------------------------------------|---------------------------|
+| `assertEquals(expected, actual)`           | Value equality            |
+| `assertNotNull(actual)`                    | Non-null check            |
+| `assertNull(actual)`                       | Null check                |
+| `assertTrue(condition)`                    | Boolean condition         |
+| `assertFalse(condition)`                   | Negated boolean condition |
+| `assertThrows(ExceptionClass, executable)` | Exception assertion       |
+| `assertDoesNotThrow(executable)`           | No-exception assertion    |
+
+```java
+assertNotNull(result);
+
+assertEquals(ROUTE_ID, result.id());
+
+assertThrows(EnduranceTrioException .class, () ->underTest.
+
+create(invalidDTO));
+
+verify(routeRepository, times(1)).
+
+save(expectedEntity);
+```
+
+### Bean Validation Tests
+
+Custom validation constraints must be tested with a programmatic `Validator` instance bootstrapped
+via `jakarta.validation.Validation`. The class must be **package-private** and requires no
+`@ExtendWith` annotation.
+
+- The `Validator` field must be named `underTest`.
+- Use a `try-with-resources` block in `@BeforeEach` to acquire and close the
+  `ValidatorFactory` (it implements `AutoCloseable`).
+- Test both valid and invalid inputs — assert the violation set size and individual violation
+  messages.
+
+```java
+class RouteSegmentsValidatorTest {
+
+  private Validator underTest;
+
+  @BeforeEach
+  void setUp() {
+    try (var factory = Validation.buildDefaultValidatorFactory()) {
+      underTest = factory.getValidator();
+    }
+  }
+
+  @Test
+  void isValid() {
+    var violations = underTest.validate(validRoute);
+    assertTrue(violations.isEmpty());
+  }
+
+  @Test
+  void isValidWithInvalidFirstOrder() {
+    Set<ConstraintViolation<RouteDTO>> result = underTest.validate(invalidRoute);
+    assertEquals(1, result.size());
+    assertEquals("Route must start with a segment of order 1",
+        result.iterator().next().getMessage()
+    );
+  }
+}
+```
+
+### Controller & Security Tests (Pure Unit)
+
+The `endurancetrio-app` module tests controllers, security filters, security configuration,
+and exception handlers using pure Mockito — no Spring context is loaded.
+
+#### Controller Tests
+
+Controller tests use `@ExtendWith(MockitoExtension.class)` with `@Mock` on the service interface
+and `@InjectMocks` on the controller implementation. The controller methods are called directly;
+`ResponseEntity<EnduranceTrioResponse<T>>` status codes and body structure are asserted.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class RouteRestControllerTest {
+
+  @Mock
+  private RouteService routeService;
+
+  @InjectMocks
+  private RouteRestController underTest;
+
+  @Test
+  void findAllShouldReturnList() {
+    when(routeService.findAll()).thenReturn(List.of(testRoute));
+
+    ResponseEntity<EnduranceTrioResponse<List<RouteDTO>>> response = underTest.findAll();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(200, response.getBody().status());
+    assertEquals(1, response.getBody().data().size());
+  }
+}
+```
+
+#### Security Filter Tests
+
+Security filter tests use `mock(HttpServletRequest.class)` for the request, 
+`MockHttpServletResponse` for the response, and `mock(FilterChain.class)` for the chain.
+Various header combinations (valid, missing, malformed) are exercised.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthFilterTest {
+
+  @Mock
+  private AuthenticationManager authManager;
+
+  @InjectMocks
+  private EnduranceTrioAuthFilter underTest;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    response = new MockHttpServletResponse();
+    filterChain = mock(FilterChain.class);
+  }
+
+  @Test
+  void missingAuthHeaderShouldSkipAuth() {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+}
+```
+
+#### Security Configuration Tests
+
+Configuration tests directly instantiate the config class and use 
+`mock(HttpSecurity.class, RETURNS_SELF)` for the fluent `HttpSecurity` API.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class AppSecurityConfigTest {
+
+  @Mock
+  private EnduranceTrioAuthProvider authProvider;
+
+  @Test
+  void corsConfigurationSourceShouldConfigureAllowedOrigins() {
+    AppSecurityConfig config = new AppSecurityConfig("http://localhost:3000",
+        authProvider, entryPoint
+    );
+
+    CorsConfigurationSource source = config.corsConfigurationSource();
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig.getAllowedOrigins());
+    assertTrue(corsConfig.getAllowedOrigins().contains("http://localhost:3000"));
+  }
+
+  @Test
+  void securityFilterChainAPIShouldBuildSuccessfully() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    HttpSecurity http = mock(HttpSecurity.class, RETURNS_SELF);
+    when(http.build()).thenReturn(mock(DefaultSecurityFilterChain.class));
+
+    assertSame(chain, config.securityFilterChainAPI(http));
+  }
+}
+```
+
+#### Exception Handler Tests
+
+Exception handler tests call `@ControllerAdvice` methods directly, asserting that each
+`EnduranceTrioError` code maps to the correct HTTP status.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerAPITest {
+
+  @InjectMocks
+  private EnduranceTrioExceptionHandlerAPI underTest;
+
+  @Test
+  void handledExceptionShouldReturnMappedHttpStatus() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.NOT_FOUND));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+  }
+}
+```
+
+### Test Configuration
+
+The file `endurancetrio-app/src/test/resources/application-test.yaml` exists and configures H2
+(PostgreSQL compatibility mode) with Flyway pointing to `h2` migration scripts. This configuration
+is intended for future integration tests (`@DataJpaTest`, `@SpringBootTest`, etc.) but is **not
+currently activated** by any test.
+
+```yaml
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:endurancetrio_tracker;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    username: user
+    password: password
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 0
+    enabled: true
+    locations:
+      - classpath:db/migration/ddl/h2
+      - classpath:db/migration/dml/h2
+    schemas: endurancetrio_tracker
+```
+
+### Flyway in Tests
+
+Flyway migration scripts are **duplicated** for H2 alongside PostgreSQL:
+
+- `src/main/resources/db/migration/ddl/h2/` — H2-specific DDL
+- `src/main/resources/db/migration/dml/h2/` — H2-specific DML
+
+When adding a new migration, the H2 variant must be added in the same version as the PostgreSQL
+variant. The `application-test.yaml` configures Flyway to use these H2 scripts.
+
+### Future: Spring Context Integration Tests
+
+The sections above document the **current** pure-Mockito test patterns for the `endurancetrio-app`
+module (controllers, security, exception handlers). The following starters are also declared in
+`endurancetrio-app/pom.xml` and ready for use when Spring-context integration tests are added:
+
+- `spring-boot-starter-webmvc-test` — `@WebMvcTest` + `MockMvc` for controller-layer tests
+- `spring-boot-starter-security-test` — Security-aware test utilities (e.g., `@WithMockUser`,
+  `RequestPostProcessor`)
+- `spring-boot-starter-actuator-test` — Actuator endpoint testing
+
+When writing integration tests that require a Spring context:
+
+1. Use `@ActiveProfiles("test")` to activate the H2/Flyway configuration.
+2. Prefer slice tests (`@WebMvcTest`, `@DataJpaTest`) over full `@SpringBootTest`.
+3. Do **not** use `@MockBean` — keep Mockito-based service tests pure (no Spring context).
+4. Add a `@TestMethodOrder(MethodOrderer.OrderAnnotation.class)` + `@Order(N)` only when test
+   ordering is explicitly required.
 
 ## Programmatic Version Management
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -499,6 +499,334 @@ public interface UserRepository extends JpaRepository<User, Long> {
 }
 ```
 
+### Entity Layer
+
+This section documents how JPA entities should be created and managed in the `endurancetrio-data`
+module.
+
+#### Package Structure
+
+Each domain group follows a consistent package layout under
+`com.endurancetrio.data.{domain}.model`:
+
+```
+{domain}/
+  model/
+    converter/          → JPA AttributeConverter implementations
+    entity/             → JPA entity classes
+    enumerator/         → Code-backed enums stored as VARCHAR columns
+```
+
+#### Base Classes
+
+Two base class options are available, chosen based on the primary key strategy:
+
+**1. `BaseEntity<Long>`** — for entities with a surrogate, sequence-generated `id`:
+
+- **`id`** — auto-generated primary key via `GenerationType.SEQUENCE`
+- **`version`** — optimistic locking field (`@Version`)
+- **`createdAt` / `updatedAt`** — auditing timestamps via `@CreatedDate` / `@LastModifiedDate`
+- **`equals()` / `hashCode()`** — ID-based equality (same class + same non-null ID)
+
+```java
+public class MyEntity extends BaseEntity<Long> { ... }
+```
+
+Only entities that need a non-`Long` ID type should extend `BaseEntity` with a different type
+parameter; currently all entities use `Long`.
+
+**2. `AuditableEntity`** — for entities with a natural (business) primary key that is assigned
+rather than generated:
+
+- **`version`** — optimistic locking field (`@Version`)
+- **`createdAt` / `updatedAt`** — auditing timestamps via `@CreatedDate` / `@LastModifiedDate`
+- **No auto-generated ID** — the entity defines its own `@Id` on a natural key field
+
+```java
+public class MyEntity extends AuditableEntity { ... }
+```
+
+#### Entity Declaration
+
+```java
+
+@Entity(name = "MyEntity")
+@Table(name = "my_entity")
+@SequenceGenerator(
+    name = "seq_endurancetrio_generator",
+    sequenceName = "seq_my_entity_id",
+    allocationSize = 1
+)
+public class MyEntity extends BaseEntity<Long> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+```
+
+- `@Entity(name = "...")` must use the simple PascalCase class name.
+- `@Table(name = "...")` must use snake_case, plural table names matching the database schema.
+- `@SequenceGenerator` must use the shared generator name `seq_endurancetrio_generator` and a
+  sequence name following the pattern `seq_{table}_id`.
+- Every entity must declare `@Serial private static final long serialVersionUID = 1L`.
+
+#### Natural Key Entities
+
+Entities with a natural (business) primary key extend `AuditableEntity` directly rather than
+`BaseEntity<Long>`. This pattern is used when the primary key is assigned in application code and
+has business meaning (e.g., `TrackerAccount` keyed by `owner`).
+
+```java
+@Entity
+@Table(name = "my_natural_entity")
+public class MyNaturalEntity extends AuditableEntity {
+
+  @Id
+  @Column(name = "natural_key", nullable = false, unique = true, length = 50)
+  private String naturalKey;
+```
+
+- `@Entity` does **not** require a `name` attribute; the class name is used by default.
+- No `@SequenceGenerator` is declared — the identifier is assigned, not generated.
+- The `@Id` field is the natural key and must be annotated with `@Column(unique = true)`.
+- `equals()` and `hashCode()` are based on the natural key field(s), not delegated to `super`.
+- Use `@Column(length = ...)` to constrain the natural key column size.
+
+#### Javadoc Convention
+
+Every entity must have a class-level Javadoc block describing what the entity represents, followed
+by a `<ul>` documenting each field with a link to its getter:
+
+```java
+/**
+ * The {@link MyEntity} entity represents ...
+ * <p>
+ * The {@link MyEntity}'s fields are defined as follows:
+ * <ul>
+ *   <li>
+ *     {@link #getId() id} : the unique identifier ...
+ *   </li>
+ *   <li>
+ *     {@link #getFieldName() fieldName} : the description ...
+ *   </li>
+ * </ul>
+ */
+```
+
+#### Constructor
+
+Always provide a public no-argument constructor that calls `super()`. Initialize collection fields
+to `new HashSet<>()` in the constructor:
+
+```java
+public MyEntity() {
+  super();
+  this.children = new HashSet<>();
+}
+```
+
+#### Field & Column Naming
+
+- Fields follow camelCase in Java.
+- `@Column(name = "...")` uses snake_case matching the database column.
+- Nullable columns omit `nullable`; required columns use `nullable = false`.
+- Boolean fields use the `is` prefix for the field name (e.g., `isActive`) and `get`/`set` prefix
+  for accessors (e.g., `getActive()`, `setActive()`).
+- Enum fields are annotated with `@Convert(converter = XxxConverter.class)` and stored as VARCHAR
+  codes, never as ORDINAL.
+- Validation annotations (`@Pattern`, `@AssertTrue`) are placed on the field directly.
+
+```java
+
+@Column(name = "full_name", nullable = false)
+private String fullName;
+
+@Column(name = "is_active", nullable = false)
+private Boolean isActive;
+
+@Column(name = "race_type", nullable = false)
+@Convert(converter = RaceTypeConverter.class)
+private RaceType raceType;
+```
+
+#### Associations
+
+All associations use `FetchType.LAZY`. Use `Set<>` (not `List`) for collection fields:
+
+| Annotation    | Cascade                  | Example                                                         |
+|---------------|--------------------------|-----------------------------------------------------------------|
+| `@ManyToOne`  | None                     | `@ManyToOne(fetch = FetchType.LAZY)`                            |
+| `@OneToOne`   | `ALL` + `orphanRemoval`  | `@OneToOne(fetch = LAZY, cascade = ALL, orphanRemoval = true)`  |
+| `@OneToMany`  | `ALL` + `orphanRemoval`  | `@OneToMany(fetch = LAZY, cascade = ALL, orphanRemoval = true)` |
+| `@ManyToMany` | `PERSIST, MERGE` or none | `@ManyToMany(fetch = FetchType.LAZY)`                           |
+
+- `@OneToMany` with `@JoinColumn` (foreign key on child table) is preferred over `mappedBy` when the
+  child has no inverse reference.
+- `@ManyToMany` always uses a `@JoinTable` with explicit join column names.
+
+#### Bidirectional Helper Methods
+
+When both sides of a relationship exist, provide `addXxx` / `removeXxx` helper methods that maintain
+consistency on both sides:
+
+```java
+public void addChild(Child child) {
+  if (child != null && this.children.add(child)) {
+    child.setParent(this);
+  }
+}
+
+public void removeChild(Child child) {
+  if (child != null && this.children.remove(child)) {
+    child.setParent(null);
+  }
+}
+```
+
+#### Method Ordering
+
+Methods in an entity class follow this order:
+
+1. Javadoc + class declaration
+2. `@Serial` / `serialVersionUID`
+3. Fields (simple columns first, associations last)
+4. Constructor(s)
+5. `@AssertTrue` validation methods
+6. Bidirectional helper methods (`addXxx` / `removeXxx`)
+7. Getters and setters (alphabetically by field name)
+8. `equals(Object)` → delegates to `super.equals(o)` (or natural key check for `AuditableEntity` entities)
+9. `hashCode()` → delegates to `super.hashCode()` (or natural key hash for `AuditableEntity` entities)
+10. `toString()` → uses `StringJoiner`
+
+#### equals(), hashCode() and toString()
+
+- **Surrogate key entities** (extending `BaseEntity`): `equals()` and `hashCode()` must delegate to
+  `super` (the `BaseEntity` ID-based contract):
+
+```java
+@Override
+public boolean equals(Object o) {
+  return super.equals(o);
+}
+
+@Override
+public int hashCode() {
+  return super.hashCode();
+}
+```
+
+- **Natural key entities** (extending `AuditableEntity` directly): `equals()` and `hashCode()` must
+  be implemented based on the natural key field(s):
+
+```java
+@Override
+public boolean equals(Object o) {
+  if (this == o) {
+    return true;
+  }
+
+  if (!(o instanceof NaturalKeyEntity that)) {
+    return false;
+  }
+
+  Class<?> thisClass = org.hibernate.Hibernate.getClass(this);
+  Class<?> thatClass = org.hibernate.Hibernate.getClass(that);
+
+  if (thisClass != thatClass) {
+    return false;
+  }
+
+  return naturalKey != null && naturalKey.equals(that.getNaturalKey());
+}
+
+@Override
+public int hashCode() {
+  return Objects.hash(naturalKey);
+}
+```
+
+- `toString()` must use `StringJoiner` with the pattern
+  `EntityName.class.getSimpleName() + "[", "]"`. Include all scalar fields and, for associations,
+  only the referenced entity's ID (using
+  `Optional.ofNullable(...).map(X::getId).orElse(null)`):
+
+```java
+
+@Override
+public String toString() {
+  return new StringJoiner(", ", MyEntity.class.getSimpleName() + "[", "]")
+      .add("id=" + this.getId())
+      .add("name='" + name + "'")
+      .add("parentId=" + Optional.ofNullable(parent).map(Parent::getId).orElse(null))
+      .toString();
+}
+```
+
+#### Enums
+
+All persisted enums must use a code-based pattern with a dedicated JPA `AttributeConverter`:
+
+```java
+public enum MyEnum {
+  VALUE_A("VALUE_A"),
+  VALUE_B("VALUE_B");
+
+  private final String code;
+
+  MyEnum(String code) {
+    this.code = code;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public String toString() {
+    return code;
+  }
+}
+```
+
+**Converter:**
+
+```java
+
+@Converter
+public class MyEnumConverter implements AttributeConverter<MyEnum, String> {
+
+  @Override
+  public String convertToDatabaseColumn(MyEnum value) {
+    return Optional.ofNullable(value).map(MyEnum::getCode).orElse(null);
+  }
+
+  @Override
+  public MyEnum convertToEntityAttribute(String code) {
+    return Stream.of(MyEnum.values())
+        .filter(e -> e.getCode().equals(code))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "The value '" + code + "' returned from the database is not a valid MyEnum code"));
+  }
+}
+```
+
+- Enums live in `{domain}.model.enumerator`.
+- Converters live in `{domain}.model.converter`.
+- Never use `EnumType.ORDINAL` or `EnumType.STRING` — always go through a converter.
+
+#### Inheritance
+
+Use `@Inheritance(strategy = InheritanceType.JOINED)` when entities share a common base table:
+
+```java
+
+@Entity(name = "Race")
+@Table(name = "race")
+@Inheritance(strategy = InheritanceType.JOINED)
+public class Race extends BaseEntity<Long> { ...
+}
+```
+
 ### Configuration File Key Ordering
 
 All `application-*.yaml` and `*.properties` files must follow a consistent key ordering convention

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,9 +13,10 @@ an overview of the project, see the [main README.md](../README.md).
 6. [Installation](#installation)
 7. [Run the application](#run-the-application)
 8. [Code & Naming Conventions](#code--naming-conventions)
-9. [Programmatic Version Management](#programmatic-version-management)
-10. [Building Custom Images with Workflow Dispatch](#building-custom-images-with-workflow-dispatch)
-11. [SonarQube Cloud Configuration](#sonarqube-cloud-configuration)
+9. [Testing](#testing)
+10. [Programmatic Version Management](#programmatic-version-management)
+11. [Building Custom Images with Workflow Dispatch](#building-custom-images-with-workflow-dispatch)
+12. [SonarQube Cloud Configuration](#sonarqube-cloud-configuration)
 
 ## Technology Stack
 
@@ -821,8 +822,7 @@ public MyEntity() {
 - `@Column(name = "...")` uses snake_case matching the database column.
 - Nullable columns omit `nullable`; required columns use `nullable = false`.
 - Boolean fields use the `is` prefix for the field name (e.g., `isActive`) and `get`/`set` prefix
-  for
-  accessors (e.g., `getActive()`, `setActive()`).
+  for accessors (e.g., `getActive()`, `setActive()`).
 - Enum fields are annotated with `@Convert(converter = XxxConverter.class)` and stored as VARCHAR
   codes, never as ORDINAL.
 - Validation annotations (`@Pattern`, `@AssertTrue`) are placed on the field directly.
@@ -1066,6 +1066,452 @@ spring:
 > `username` appears before the alphabetically-earlier `password` because they form a credentials
 > pair.
 
+## Testing
+
+This section documents the testing standards, conventions, and practices for the project. All tests
+must comply with these rules.
+
+### Testing Approach
+
+All tests are **pure unit tests** — fast, isolated, and requiring no Spring context. There are three
+categories:
+
+| Category                  | Description                                                            | Framework                    |
+|---------------------------|------------------------------------------------------------------------|------------------------------|
+| **Plain POJO tests**      | Entities, DTOs, responses — verify constructors, accessors, `toString` | JUnit 5 only                 |
+| **Mockito-based tests**   | Services, mappers — mock dependencies to isolate the class under test  | JUnit 5 + Mockito            |
+| **Bean Validation tests** | Custom validation annotations — programmatic `Validator` setup         | JUnit 5 + Jakarta Validation |
+
+No test currently loads a Spring application context (`@SpringBootTest`, `@DataJpaTest`,
+`@WebMvcTest`, etc.). If integration tests are added in the future, they must use the existing
+[test configuration](#test-configuration).
+
+### Test Frameworks & Dependencies
+
+| Dependency                            | Scope                            | Used In Module           |
+|---------------------------------------|----------------------------------|--------------------------|
+| **JUnit 5** (Jupiter)                 | Inherited via Spring Boot parent | All modules              |
+| **Mockito**                           | Inherited via Spring Boot parent | `endurancetrio-business` |
+| `spring-boot-starter-data-jpa-test`   | Test                             | `endurancetrio-data`     |
+| `spring-boot-starter-flyway-test`     | Test                             | `endurancetrio-data`     |
+| `com.h2database:h2`                   | Test                             | `endurancetrio-data`     |
+| `spring-boot-starter-validation-test` | Test                             | `endurancetrio-business` |
+| `spring-boot-starter-actuator-test`   | Test                             | `endurancetrio-app`      |
+| `spring-boot-starter-webmvc-test`     | Test                             | `endurancetrio-app`      |
+| `spring-boot-starter-security-test`   | Test                             | `endurancetrio-app`      |
+
+Module-specific test starters are declared **per module** based on what that module needs to test.
+JUnit 5 and Mockito are inherited from the Spring Boot parent POM via `spring-boot-starter-test`.
+
+### Test Class Naming
+
+All test classes must follow the pattern:
+
+```
+{ClassUnderTest}Test.java
+```
+
+| Test Class                   | Tests Class              |
+|------------------------------|--------------------------|
+| `TrackerAccountTest`         | `TrackerAccount`         |
+| `RouteServiceMainTest`       | `RouteServiceMain`       |
+| `DeviceTelemetryMapperTest`  | `DeviceTelemetryMapper`  |
+| `RouteSegmentsValidatorTest` | `RouteSegmentsValidator` |
+
+Service implementations use the `Main` suffix (not `Impl`), so their tests follow the same naming
+(e.g., `RouteServiceMain` → `RouteServiceMainTest`).
+
+### Test Class Declaration
+
+- Class must be **package-private** (no `public` modifier).
+- No class-level annotation for plain POJO tests.
+- `@ExtendWith(MockitoExtension.class)` must be present on Mockito-based tests.
+- Bean Validation tests use a programmatic `Validator` bootstrap in `@BeforeEach` (no Mockito
+  extension required).
+
+```java
+// Plain POJO test — no annotation
+class TrackerAccountTest { ...
+}
+
+// Mockito test — single annotation
+@ExtendWith(MockitoExtension.class)
+class RouteServiceMainTest { ...
+}
+
+// Bean Validation test — programmatic Validator, no Mockito
+class RouteSegmentsValidatorTest { ...
+}
+```
+
+### Test Structure
+
+#### Field Conventions
+
+- **Constants**: `private static final` fields at the top of the class.
+- **Test fixture objects**: declared as `private` instance fields.
+- **Mock dependencies**: annotated with `@Mock`.
+- **Class under test**: annotated with `@InjectMocks`, field named `underTest`.
+
+```java
+private static final String OWNER = "system";
+private static final Long DEVICE_ID = 12345L;
+
+@Mock
+private RouteMapper routeMapper;
+
+@Mock
+private RouteRepository routeRepository;
+
+@InjectMocks
+private RouteServiceMain underTest;
+```
+
+#### Setup Method
+
+A single `@BeforeEach void setUp()` method must create all test fixtures:
+
+```java
+@BeforeEach
+void setUp() {
+    testAccount = new TrackerAccount(OWNER, KEY, true);
+    var device = new DeviceTelemetry();
+    device.setId(DEVICE_ID);
+    existingDevices = Set.of(device);
+}
+```
+
+#### Test Method Naming
+
+Test methods use `camelCase` describing the scenario:
+
+| Pattern           | Examples                                                                               |
+|-------------------|----------------------------------------------------------------------------------------|
+| POJO/Record tests | `dtoShouldRetainValues`, `entityShouldRetainValues`                                    |
+| Happy path        | `create`, `update`, `findAll`, `findById`, `save`, `validateKey`                       |
+| Error/edge case   | `createWithIdShouldThrow`, `updateWithNonExistingRoute`, `validateKeyWithUnknownOwner` |
+| Empty data        | `findAllWhenNoRoutesExist`, `findMostRecentRecordForEachDeviceWithEmptyData`           |
+| Null safety       | `mapNullDTO`, `mapNullEntity`, `updateEntityWithNullDTO`                               |
+| Validation        | `isValid`, `isValidWithInvalidFirstOrder`                                              |
+
+### Mocking Standards
+
+#### Annotations
+
+- `@Mock` for all dependencies.
+- `@InjectMocks` for the class under test.
+
+```java
+
+@Mock
+private RouteMapper routeMapper;
+
+@Mock
+private RouteRepository routeRepository;
+
+@InjectMocks
+private RouteServiceMain underTest;
+```
+
+#### Stubbing Patterns
+
+| Scenario              | Pattern                                                  |
+|-----------------------|----------------------------------------------------------|
+| Return value          | `when(mock.method(...)).thenReturn(value)`               |
+| Return based on input | `when(mock.method(...)).thenAnswer(invocation -> ...)`   |
+| Void method           | `doAnswer(invocation -> { ... }).when(mock).method(...)` |
+| Argument matchers     | `any()`, `anySet()`, `any(RouteDTO.class)`               |
+| Custom matching       | `argThat(arg -> condition)`                              |
+
+#### Verification
+
+```java
+verify(repository, times(1)).
+
+save(entity);
+
+verify(mapper, never()).
+
+map(any());
+```
+
+#### Private Field Injection
+
+Use `ReflectionTestUtils.setField()` only when the class under test has `@Value`-injected fields
+that would normally be set by Spring:
+
+```java
+ReflectionTestUtils.setField(underTest, "firstOwner",OWNER);
+```
+
+### Assertion Style
+
+The project's tests currently use `org.junit.jupiter.api.Assertions.*` static imports for all
+assertions. JUnit 5 assertions (`assertEquals`, `assertNotNull`, `assertThrows`, etc.) remain the
+default and are preferred for consistency with existing test classes.
+
+Other assertion libraries may be used in new tests at the developer's discretion. Notable options:
+
+- **AssertJ** — fluent API with better diagnostics (e.g., `usingRecursiveComparison` for DTO
+  comparison, collection extraction, no parameter-order ambiguity). Already available on the
+  classpath via `spring-boot-starter-test`.
+- **Hamcrest** — matcher-based, legacy. Not recommended.
+- **Truth** — Google's assertion library. Not recommended.
+
+| Assertion                                  | Usage                     |
+|--------------------------------------------|---------------------------|
+| `assertEquals(expected, actual)`           | Value equality            |
+| `assertNotNull(actual)`                    | Non-null check            |
+| `assertNull(actual)`                       | Null check                |
+| `assertTrue(condition)`                    | Boolean condition         |
+| `assertFalse(condition)`                   | Negated boolean condition |
+| `assertThrows(ExceptionClass, executable)` | Exception assertion       |
+| `assertDoesNotThrow(executable)`           | No-exception assertion    |
+
+```java
+assertNotNull(result);
+
+assertEquals(ROUTE_ID, result.id());
+
+assertThrows(EnduranceTrioException .class, () ->underTest.
+
+create(invalidDTO));
+
+verify(routeRepository, times(1)).
+
+save(expectedEntity);
+```
+
+### Bean Validation Tests
+
+Custom validation constraints must be tested with a programmatic `Validator` instance bootstrapped
+via `jakarta.validation.Validation`. The class must be **package-private** and requires no
+`@ExtendWith` annotation.
+
+- The `Validator` field must be named `underTest`.
+- Use a `try-with-resources` block in `@BeforeEach` to acquire and close the
+  `ValidatorFactory` (it implements `AutoCloseable`).
+- Test both valid and invalid inputs — assert the violation set size and individual violation
+  messages.
+
+```java
+class RouteSegmentsValidatorTest {
+
+  private Validator underTest;
+
+  @BeforeEach
+  void setUp() {
+    try (var factory = Validation.buildDefaultValidatorFactory()) {
+      underTest = factory.getValidator();
+    }
+  }
+
+  @Test
+  void isValid() {
+    var violations = underTest.validate(validRoute);
+    assertTrue(violations.isEmpty());
+  }
+
+  @Test
+  void isValidWithInvalidFirstOrder() {
+    Set<ConstraintViolation<RouteDTO>> result = underTest.validate(invalidRoute);
+    assertEquals(1, result.size());
+    assertEquals("Route must start with a segment of order 1",
+        result.iterator().next().getMessage()
+    );
+  }
+}
+```
+
+### Controller & Security Tests (Pure Unit)
+
+The `endurancetrio-app` module tests controllers, security filters, security configuration,
+and exception handlers using pure Mockito — no Spring context is loaded.
+
+#### Controller Tests
+
+Controller tests use `@ExtendWith(MockitoExtension.class)` with `@Mock` on the service interface
+and `@InjectMocks` on the controller implementation. The controller methods are called directly;
+`ResponseEntity<EnduranceTrioResponse<T>>` status codes and body structure are asserted.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class RouteRestControllerTest {
+
+  @Mock
+  private RouteService routeService;
+
+  @InjectMocks
+  private RouteRestController underTest;
+
+  @Test
+  void findAllShouldReturnList() {
+    when(routeService.findAll()).thenReturn(List.of(testRoute));
+
+    ResponseEntity<EnduranceTrioResponse<List<RouteDTO>>> response = underTest.findAll();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(200, response.getBody().status());
+    assertEquals(1, response.getBody().data().size());
+  }
+}
+```
+
+#### Security Filter Tests
+
+Security filter tests use `mock(HttpServletRequest.class)` for the request,
+`MockHttpServletResponse` for the response, and `mock(FilterChain.class)` for the chain.
+Various header combinations (valid, missing, malformed) are exercised.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthFilterTest {
+
+  @Mock
+  private AuthenticationManager authManager;
+
+  @InjectMocks
+  private EnduranceTrioAuthFilter underTest;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    response = new MockHttpServletResponse();
+    filterChain = mock(FilterChain.class);
+  }
+
+  @Test
+  void missingAuthHeaderShouldSkipAuth() {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+}
+```
+
+#### Security Configuration Tests
+
+Configuration tests directly instantiate the config class and use 
+`mock(HttpSecurity.class, RETURNS_SELF)` for the fluent `HttpSecurity` API.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class AppSecurityConfigTest {
+
+  @Mock
+  private EnduranceTrioAuthProvider authProvider;
+
+  @Test
+  void corsConfigurationSourceShouldConfigureAllowedOrigins() {
+    AppSecurityConfig config = new AppSecurityConfig("http://localhost:3000",
+        authProvider, entryPoint
+    );
+
+    CorsConfigurationSource source = config.corsConfigurationSource();
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig.getAllowedOrigins());
+    assertTrue(corsConfig.getAllowedOrigins().contains("http://localhost:3000"));
+  }
+
+  @Test
+  void securityFilterChainAPIShouldBuildSuccessfully() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    HttpSecurity http = mock(HttpSecurity.class, RETURNS_SELF);
+    when(http.build()).thenReturn(mock(DefaultSecurityFilterChain.class));
+
+    assertSame(chain, config.securityFilterChainAPI(http));
+  }
+}
+```
+
+#### Exception Handler Tests
+
+Exception handler tests call `@ControllerAdvice` methods directly, asserting that each
+`EnduranceTrioError` code maps to the correct HTTP status.
+
+```java
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerAPITest {
+
+  @InjectMocks
+  private EnduranceTrioExceptionHandlerAPI underTest;
+
+  @Test
+  void handledExceptionShouldReturnMappedHttpStatus() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.NOT_FOUND));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+  }
+}
+```
+
+### Test Configuration
+
+The file `endurancetrio-app/src/test/resources/application-test.yaml` exists and configures H2
+(PostgreSQL compatibility mode) with Flyway pointing to `h2` migration scripts. This configuration
+is intended for future integration tests (`@DataJpaTest`, `@SpringBootTest`, etc.) but is **not
+currently activated** by any test.
+
+```yaml
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:endurancetrio_tracker;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    username: user
+    password: password
+  flyway:
+    baseline-on-migrate: true
+    baseline-version: 0
+    enabled: true
+    locations:
+      - classpath:db/migration/ddl/h2
+      - classpath:db/migration/dml/h2
+    schemas: endurancetrio_tracker
+```
+
+### Flyway in Tests
+
+Flyway migration scripts are **duplicated** for H2 alongside PostgreSQL:
+
+- `src/main/resources/db/migration/ddl/h2/` — H2-specific DDL
+- `src/main/resources/db/migration/dml/h2/` — H2-specific DML
+
+When adding a new migration, the H2 variant must be added in the same version as the PostgreSQL
+variant. The `application-test.yaml` configures Flyway to use these H2 scripts.
+
+### Future: Spring Context Integration Tests
+
+The sections above document the **current** pure-Mockito test patterns for the `endurancetrio-app`
+module (controllers, security, exception handlers). The following starters are also declared in
+`endurancetrio-app/pom.xml` and ready for use when Spring-context integration tests are added:
+
+- `spring-boot-starter-webmvc-test` — `@WebMvcTest` + `MockMvc` for controller-layer tests
+- `spring-boot-starter-security-test` — Security-aware test utilities (e.g., `@WithMockUser`,
+  `RequestPostProcessor`)
+- `spring-boot-starter-actuator-test` — Actuator endpoint testing
+
+When writing integration tests that require a Spring context:
+
+1. Use `@ActiveProfiles("test")` to activate the H2/Flyway configuration.
+2. Prefer slice tests (`@WebMvcTest`, `@DataJpaTest`) over full `@SpringBootTest`.
+3. Do **not** use `@MockBean` — keep Mockito-based service tests pure (no Spring context).
+4. Add a `@TestMethodOrder(MethodOrderer.OrderAnnotation.class)` + `@Order(N)` only when test
+   ordering is explicitly required.
+
 ## Programmatic Version Management
 
 Community releases are versioned independently of any integrated repositories (such as the
@@ -1293,52 +1739,66 @@ For broader deployment validation (health checks, logs, rollback flow), follow
 
 The **EnduranceTrio** project uses [SonarQube Cloud](https://sonarcloud.io/) for continuous code quality
 inspection. The repository is linked to SonarQube Cloud via the GitHub App integration, which
-automatically decorates pull requests with analysis results and performs automatic analysis
-on every push.
+automatically decorates pull requests with analysis results.
+
+Two analysis methods are available, configured by separate files:
+
+| Method                      | Config file                | Used by                                                             |
+|-----------------------------|----------------------------|---------------------------------------------------------------------|
+| **Automatic Analysis**      | `.sonarcloud.properties`   | SonarCloud's built-in scanner (push/PR on default branch)           |
+| **CLI / CI-based analysis** | `sonar-project.properties` | `mvn verify sonar:sonar` locally, or future GitHub Actions workflow |
+
+Both files are kept aligned and should always define the same exclusions.
 
 ### Repository Configuration
 
-The following configuration is already in place for the project:
+The following configuration is in place for the project:
 
 1. **`pom.xml`** — the `<sonar.organization>` property is set in the root POM to identify the
-   SonarQube Cloud organization (`endurancecode`).
-2. **`sonar-project.properties`** — the root configuration file defines the project key, the
-   SonarQube Cloud host URL, and analysis exclusions (e.g., CPD duplication detection on SQL migration
-   scripts).
+   SonarQube Cloud organization (`endurancecode`). This property is required by the
+   sonar-maven-plugin for CLI/CI analysis.
+2. **`.sonarcloud.properties`** — defines exclusions for **Automatic Analysis**:
+   - `sonar.exclusions` — excludes SQL migration scripts from analysis
+   - `sonar.cpd.exclusions` — excludes SQL migration scripts from duplication detection
+3. **`sonar-project.properties`** — defines the project key, host URL, and all exclusions for
+   **CLI/CI analysis**:
+   - `sonar.exclusions` — excludes SQL migration scripts from analysis
+   - `sonar.cpd.exclusions` — excludes SQL migration scripts from duplication detection
+   - `sonar.coverage.exclusions` — excludes boilerplate code (`**/model/entity/**`,
+     `**/model/enumerator/**`, `**/config/**`) from coverage metrics
+   - `sonar.coverage.jacoco.xmlReportPaths` — path to the JaCoCo XML report
 
-### Prerequisites for Manual Analysis
+### Manual Analysis (CLI)
 
-1. A SonarQube Cloud account with access to the `EnduranceCode` organization.
-2. A SonarQube Cloud token generated at **[Account → Security](https://sonarcloud.io/account/security)**
+A manual analysis can be triggered from the command line. Since it uses the same sonar-maven-plugin
+as the GitHub Actions workflow, it conflicts with Automatic Analysis.
+
+1. Generate a SonarQube Cloud token at **[Account → Security](https://sonarcloud.io/account/security)**
    with the **Analyze Projects** permission.
-3. The `SONAR_TOKEN` environment variable set to the generated token:
+2. Set it as an environment variable:
 
-```shell
-export SONAR_TOKEN=your_sonarcloud_token
-```
+   ```shell
+   export SONAR_TOKEN=your_sonarcloud_token
+   ```
 
-### Run a Manual Analysis
+3. **Disable Automatic Analysis** in the SonarQube Cloud project settings
+   (**Project Settings → Administration → Analysis Method → "Other CI"**). If Automatic Analysis is
+   enabled, the scanner will fail with a conflict error.
 
-Before running a manual analysis, disable **Automatic Analysis** in the SonarQube Cloud project
-settings (**Project Settings → Analysis Method → "Other CI"**). If Automatic Analysis is enabled,
-the scanner will fail with a conflict error.
+4. Run the analysis from the repository root:
 
-To trigger a full project analysis from your local machine, execute the following command from the
-repository root:
+   ```shell
+   ./mvnw verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=endurancecode_endurancetrio-community
+   ```
 
-```shell
-./mvnw verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=endurancecode_endurancetrio-community
-```
+   This will:
+   - Build the project and run all tests (generating the JaCoCo coverage report)
+   - Execute the SonarScanner, which reads `sonar-project.properties` from the repository root
+   - Send the analysis results (including coverage) to SonarQube Cloud
+   - Apply all configured exclusions (CPD, analysis, and coverage)
 
-This will:
-- Build the project and run all tests
-- Execute the SonarScanner, which reads `sonar-project.properties` from the repository root
-- Send the analysis results to SonarQube Cloud, creating a new baseline for the project
-- Apply any configured exclusions (e.g., CPD for SQL migration scripts)
+5. After the manual analysis completes, **re-enable Automatic Analysis** from the same settings page
+   if you want to resume automatic scans on push.
 
-After the manual analysis completes, Automatic Analysis can be re-enabled from the same settings
-page. SonarQube Cloud will immediately trigger a new analysis using the uploaded results as the
-baseline. The results are available in the
+Results are available in the
 [SonarQube Cloud dashboard](https://sonarcloud.io/project/overview?id=endurancecode_endurancetrio-community).
-Subsequent automatic analyses (triggered by future pushes) will continue to use this latest analysis
-as their baseline.

--- a/docs/development.md
+++ b/docs/development.md
@@ -532,6 +532,31 @@ spring:
 
 ## Programmatic Version Management
 
+### Version Update
+
+This project supports programmatic version updates across all Maven modules. It can be achieved
+replacing the label as appropriate in the below command and then executing it.
+
+```shell
+mvn versions:set -DnewVersion={VERSION_NUMBER}
+```
+
+> **Placeholder Definition**
+>
+> + **{VERSION_NUMBER}** : The new Sematic Version number to be applied across all Maven modules
+
+The changes applied with the above command can be reverted executing the following command:
+
+```shell
+mvn versions:revert
+```
+
+Or commited with the following command:
+
+```shell
+mvn versions:commit
+```
+
 ### Version Tagging
 
 All releases must be tagged using **annotated** tags (created with the `-a` flag) following
@@ -557,29 +582,4 @@ Push the tag to the remote repository:
 
 ```shell
 git push origin tracker-vX.Y.Z
-```
-
-### Version Bump
-
-This project supports programmatic version updates across all Maven modules. It can be achieved
-replacing the label as appropriate in the below command and then executing it.
-
-```shell
-mvn versions:set -DnewVersion={VERSION_NUMBER}
-```
-
-> **Placeholder Definition**
->
-> + **{VERSION_NUMBER}** : The new Sematic Version number to be applied across all Maven modules
-
-The changes applied with the above command can be reverted executing the following command:
-
-```shell
-mvn versions:revert
-```
-
-Or commited with the following command:
-
-```shell
-mvn versions:commit
 ```

--- a/endurancetrio-app/pom.xml
+++ b/endurancetrio-app/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.endurancetrio</groupId>
     <artifactId>endurancetrio-tracker</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/config/LocaleRedirectFilter.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/config/LocaleRedirectFilter.java
@@ -45,7 +45,8 @@ public class LocaleRedirectFilter implements Filter {
     String uri = httpRequest.getRequestURI();
     if (uri.startsWith("/css/") || uri.startsWith("/js/") || uri.startsWith("/img/")
         || uri.startsWith("/webjars/") || STATIC_ROOT_FILES.contains(uri) || uri.startsWith("/api/")
-        || uri.startsWith("/v3/api-docs/") || uri.startsWith("/swagger-ui")) {
+        || uri.equals("/v3/api-docs") || uri.startsWith("/v3/api-docs/") || uri.startsWith(
+        "/swagger-ui")) {
       chain.doFilter(request, response);
       return;
     }

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/tracker/api/RouteRestController.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/tracker/api/RouteRestController.java
@@ -28,9 +28,6 @@ import static com.endurancetrio.app.tracker.constants.TrackerPathsAPI.TRACKER_V1
 
 import com.endurancetrio.app.common.annotation.EnduranceTrioRestController;
 import com.endurancetrio.app.common.response.EnduranceTrioResponse;
-import com.endurancetrio.business.common.dto.ErrorDTO;
-import com.endurancetrio.business.common.exception.EnduranceTrioError;
-import com.endurancetrio.business.common.exception.EnduranceTrioException;
 import com.endurancetrio.business.tracker.dto.RouteDTO;
 import com.endurancetrio.business.tracker.dto.RouteMetricsDTO;
 import com.endurancetrio.business.tracker.service.RouteService;

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/TrackerApplicationTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/TrackerApplicationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+class TrackerApplicationTest {
+
+  @Test
+  void shouldBeAnnotatedWithSpringBootApplication() {
+    SpringBootApplication annotation = TrackerApplication.class.getAnnotation(
+        SpringBootApplication.class);
+
+    assertNotNull(annotation);
+  }
+
+  @Test
+  void shouldBeAnnotatedWithEnableJpaRepositories() {
+    EnableJpaRepositories annotation = TrackerApplication.class.getAnnotation(
+        EnableJpaRepositories.class);
+
+    assertNotNull(annotation);
+  }
+
+  @Test
+  void shouldBeAnnotatedWithEntityScan() {
+    EntityScan annotation = TrackerApplication.class.getAnnotation(EntityScan.class);
+
+    assertNotNull(annotation);
+  }
+
+  @Test
+  void shouldCreateInstance() {
+    assertDoesNotThrow(TrackerApplication::new);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/EnduranceTrioRestControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/EnduranceTrioRestControllerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RestController;
+
+class EnduranceTrioRestControllerTest {
+
+  @Test
+  void shouldBeAnnotatedWithRestController() {
+    RestController annotation = EnduranceTrioRestController.class.getAnnotation(
+        RestController.class);
+
+    assertNotNull(annotation);
+  }
+
+  @Test
+  void shouldHaveTypeTarget() {
+    Target target = EnduranceTrioRestController.class.getAnnotation(Target.class);
+
+    assertNotNull(target);
+    assertTrue(java.util.Arrays.asList(target.value()).contains(ElementType.TYPE));
+  }
+
+  @Test
+  void shouldHaveRuntimeRetention() {
+    Retention retention = EnduranceTrioRestController.class.getAnnotation(Retention.class);
+
+    assertNotNull(retention);
+    assertSame(RetentionPolicy.RUNTIME, retention.value());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/EnduranceTrioRestControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/EnduranceTrioRestControllerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RestController;
+
+class EnduranceTrioRestControllerTest {
+
+  @Test
+  void shouldBeAnnotatedWithRestController() {
+    RestController annotation = EnduranceTrioRestController.class.getAnnotation(
+        RestController.class);
+
+    assertNotNull(annotation);
+  }
+
+  @Test
+  void shouldHaveTypeTarget() {
+    Target target = EnduranceTrioRestController.class.getAnnotation(Target.class);
+
+    assertNotNull(target);
+    assertTrue(java.util.Arrays.asList(target.value()).contains(ElementType.TYPE));
+  }
+
+  @Test
+  void shouldHaveRuntimeRetention() {
+    Retention retention = EnduranceTrioRestController.class.getAnnotation(Retention.class);
+
+    assertNotNull(retention);
+    assertSame(RetentionPolicy.RUNTIME, retention.value());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/OpenApiStandardErrorsTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/OpenApiStandardErrorsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+
+class OpenApiStandardErrorsTest {
+
+  @Test
+  void shouldBeTargetedAtMethodAndType() {
+    Target target = OpenApiStandardErrors.class.getAnnotation(Target.class);
+
+    assertNotNull(target);
+    assertTrue(target.value().length >= 2);
+  }
+
+  @Test
+  void shouldHaveRuntimeRetention() {
+    Retention retention = OpenApiStandardErrors.class.getAnnotation(Retention.class);
+
+    assertNotNull(retention);
+    assertSame(RetentionPolicy.RUNTIME, retention.value());
+  }
+
+  @Test
+  void shouldHaveApiResponseAnnotations() {
+    ApiResponse[] responses = OpenApiStandardErrors.class.getAnnotationsByType(ApiResponse.class);
+
+    assertNotNull(responses);
+    assertTrue(responses.length >= 4);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/OpenApiStandardErrorsTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/annotation/OpenApiStandardErrorsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+
+class OpenApiStandardErrorsTest {
+
+  @Test
+  void shouldBeTargetedAtMethodAndType() {
+    Target target = OpenApiStandardErrors.class.getAnnotation(Target.class);
+
+    assertNotNull(target);
+    assertTrue(target.value().length >= 2);
+  }
+
+  @Test
+  void shouldHaveRuntimeRetention() {
+    Retention retention = OpenApiStandardErrors.class.getAnnotation(Retention.class);
+
+    assertNotNull(retention);
+    assertSame(RetentionPolicy.RUNTIME, retention.value());
+  }
+
+  @Test
+  void shouldHaveApiResponseAnnotations() {
+    ApiResponse[] responses = OpenApiStandardErrors.class.getAnnotationsByType(ApiResponse.class);
+
+    assertNotNull(responses);
+    assertTrue(responses.length >= 4);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/constants/ControllerConstantsTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/constants/ControllerConstantsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import org.junit.jupiter.api.Test;
+
+class ControllerConstantsTest {
+
+  @Test
+  void apiPathShouldBeApi() {
+    assertEquals("/api", ControllerConstants.API_PATH);
+  }
+
+  @Test
+  void status200ShouldBe200() {
+    assertEquals(200, ControllerConstants.STATUS_200);
+  }
+
+  @Test
+  void status500ShouldBe500() {
+    assertEquals(500, ControllerConstants.STATUS_500);
+  }
+
+  @Test
+  void msgSuccessShouldBeCorrect() {
+    assertEquals("Request handled successfully", ControllerConstants.MSG_SUCCESS);
+  }
+
+  @Test
+  void msgAuthFailureShouldBeCorrect() {
+    assertEquals("Authentication failed", ControllerConstants.MSG_AUTH_FAILURE);
+  }
+
+  @Test
+  void msgAuthDeniedShouldBeCorrect() {
+    assertEquals("Access Denied: Missing required permissions",
+        ControllerConstants.MSG_AUTH_DENIED
+    );
+  }
+
+  @Test
+  void msgServerErrorShouldBeCorrect() {
+    assertEquals("An internal server error occurred", ControllerConstants.MSG_SERVER_ERROR);
+  }
+
+  @Test
+  void privateConstructorShouldThrow() throws Exception {
+    Constructor<ControllerConstants> constructor = ControllerConstants.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
+        constructor::newInstance
+    );
+    assertEquals(IllegalStateException.class, thrown.getCause().getClass());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/constants/ControllerConstantsTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/constants/ControllerConstantsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import org.junit.jupiter.api.Test;
+
+class ControllerConstantsTest {
+
+  @Test
+  void apiPathShouldBeApi() {
+    assertEquals("/api", ControllerConstants.API_PATH);
+  }
+
+  @Test
+  void status200ShouldBe200() {
+    assertEquals(200, ControllerConstants.STATUS_200);
+  }
+
+  @Test
+  void status500ShouldBe500() {
+    assertEquals(500, ControllerConstants.STATUS_500);
+  }
+
+  @Test
+  void msgSuccessShouldBeCorrect() {
+    assertEquals("Request handled successfully", ControllerConstants.MSG_SUCCESS);
+  }
+
+  @Test
+  void msgAuthFailureShouldBeCorrect() {
+    assertEquals("Authentication failed", ControllerConstants.MSG_AUTH_FAILURE);
+  }
+
+  @Test
+  void msgAuthDeniedShouldBeCorrect() {
+    assertEquals("Access Denied: Missing required permissions",
+        ControllerConstants.MSG_AUTH_DENIED
+    );
+  }
+
+  @Test
+  void msgServerErrorShouldBeCorrect() {
+    assertEquals("An internal server error occurred", ControllerConstants.MSG_SERVER_ERROR);
+  }
+
+  @Test
+  void privateConstructorShouldThrow() throws Exception {
+    Constructor<ControllerConstants> constructor = ControllerConstants.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    InvocationTargetException thrown = assertThrows(InvocationTargetException.class,
+        constructor::newInstance
+    );
+    assertEquals(IllegalStateException.class, thrown.getCause().getClass());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAPITest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAPITest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import com.endurancetrio.business.common.dto.ErrorDTO;
+import com.endurancetrio.business.common.exception.EnduranceTrioError;
+import com.endurancetrio.business.common.exception.EnduranceTrioException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.core.MethodParameter;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.MapBindingResult;
+import org.springframework.validation.method.MethodValidationResult;
+import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerAPITest {
+
+  @InjectMocks
+  private EnduranceTrioExceptionHandlerAPI underTest;
+
+  @Test
+  void handledExceptionShouldReturnMappedHttpStatus() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.NOT_FOUND));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+  }
+
+  @Test
+  void handledExceptionShouldReturn400ForBadRequest() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.BAD_REQUEST));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void handledExceptionShouldReturn409ForConflict() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.CONFLICT));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+  }
+
+  @Test
+  void handledExceptionShouldReturn500ForInternalError() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.INTERNAL_ERROR));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+  @Test
+  void unhandledExceptionShouldReturn500() {
+    RuntimeException exception = new RuntimeException("Unexpected error");
+
+    ResponseEntity<EnduranceTrioResponse<String>> response = underTest.unhandledException(
+        exception);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(500, response.getBody().status());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void handledExceptionShouldReturnErrorsInBody() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "field is required");
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    EnduranceTrioResponse<List<ErrorDTO>> body = (EnduranceTrioResponse<List<ErrorDTO>>) response.getBody();
+
+    assertNotNull(body);
+    assertEquals(1, body.data().size());
+    assertEquals("field is required", body.data().getFirst().message());
+  }
+
+  @Test
+  void handleMethodArgumentNotValidShouldReturnValidationErrors() {
+    MapBindingResult bindingResult = new MapBindingResult(new java.util.HashMap<>(), "target");
+    bindingResult.rejectValue("fieldName", "error.code", "must not be null");
+    MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+        mock(org.springframework.core.MethodParameter.class), bindingResult);
+
+    ResponseEntity<Object> response = underTest.handleMethodArgumentNotValid(exception,
+        HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class)
+    );
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void handleConstraintViolationShouldReturnBadRequest() {
+    ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+    Path propertyPath = mock(Path.class);
+    when(propertyPath.toString()).thenReturn("fieldName");
+    when(violation.getPropertyPath()).thenReturn(propertyPath);
+    when(violation.getMessage()).thenReturn("must not be null");
+    ConstraintViolationException exception = new ConstraintViolationException("validation failed",
+        Set.of(violation)
+    );
+
+    ResponseEntity<Object> response = underTest.handleConstraintViolation(exception);
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void handleDataIntegrityShouldReturnConflict() {
+    DataIntegrityViolationException exception = new DataIntegrityViolationException(
+        "constraint violation");
+
+    ResponseEntity<Object> response = underTest.handleDataIntegrity(exception);
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+  }
+
+  @Test
+  void handleHandlerMethodValidationExceptionShouldReturnBadRequest() {
+    MethodValidationResult methodValidationResult = mock(MethodValidationResult.class);
+    ParameterValidationResult paramResult = mock(ParameterValidationResult.class);
+    MethodParameter methodParam = mock(MethodParameter.class);
+    MessageSourceResolvable error = mock(MessageSourceResolvable.class);
+    when(methodParam.getParameterName()).thenReturn("paramName");
+    when(paramResult.getMethodParameter()).thenReturn(methodParam);
+    when(error.getDefaultMessage()).thenReturn("must not be null");
+    when(paramResult.getResolvableErrors()).thenReturn(List.of(error));
+    when(methodValidationResult.getParameterValidationResults()).thenReturn(List.of(paramResult));
+
+    HandlerMethodValidationException exception = new HandlerMethodValidationException(
+        methodValidationResult);
+
+    ResponseEntity<Object> response = underTest.handleHandlerMethodValidationException(exception,
+        HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class)
+    );
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAPITest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAPITest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import com.endurancetrio.business.common.dto.ErrorDTO;
+import com.endurancetrio.business.common.exception.EnduranceTrioError;
+import com.endurancetrio.business.common.exception.EnduranceTrioException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.core.MethodParameter;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.MapBindingResult;
+import org.springframework.validation.method.MethodValidationResult;
+import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerAPITest {
+
+  @InjectMocks
+  private EnduranceTrioExceptionHandlerAPI underTest;
+
+  @Test
+  void handledExceptionShouldReturnMappedHttpStatus() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.NOT_FOUND));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+  }
+
+  @Test
+  void handledExceptionShouldReturn400ForBadRequest() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.BAD_REQUEST));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void handledExceptionShouldReturn409ForConflict() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.CONFLICT));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+  }
+
+  @Test
+  void handledExceptionShouldReturn500ForInternalError() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.INTERNAL_ERROR));
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+  @Test
+  void unhandledExceptionShouldReturn500() {
+    RuntimeException exception = new RuntimeException("Unexpected error");
+
+    ResponseEntity<EnduranceTrioResponse<String>> response = underTest.unhandledException(
+        exception);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(500, response.getBody().status());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void handledExceptionShouldReturnErrorsInBody() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "field is required");
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    ResponseEntity<Object> response = underTest.handledException(exception);
+
+    EnduranceTrioResponse<List<ErrorDTO>> body = (EnduranceTrioResponse<List<ErrorDTO>>) response.getBody();
+
+    assertNotNull(body);
+    assertEquals(1, body.data().size());
+    assertEquals("field is required", body.data().getFirst().message());
+  }
+
+  @Test
+  void handleMethodArgumentNotValidShouldReturnValidationErrors() {
+    MapBindingResult bindingResult = new MapBindingResult(new java.util.HashMap<>(), "target");
+    bindingResult.rejectValue("fieldName", "error.code", "must not be null");
+    MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+        mock(org.springframework.core.MethodParameter.class), bindingResult);
+
+    ResponseEntity<Object> response = underTest.handleMethodArgumentNotValid(exception,
+        HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class)
+    );
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void handleConstraintViolationShouldReturnBadRequest() {
+    ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+    Path propertyPath = mock(Path.class);
+    when(propertyPath.toString()).thenReturn("fieldName");
+    when(violation.getPropertyPath()).thenReturn(propertyPath);
+    when(violation.getMessage()).thenReturn("must not be null");
+    ConstraintViolationException exception = new ConstraintViolationException("validation failed",
+        Set.of(violation)
+    );
+
+    ResponseEntity<Object> response = underTest.handleConstraintViolation(exception);
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
+  void handleDataIntegrityShouldReturnConflict() {
+    DataIntegrityViolationException exception = new DataIntegrityViolationException(
+        "constraint violation");
+
+    ResponseEntity<Object> response = underTest.handleDataIntegrity(exception);
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+  }
+
+  @Test
+  void handleHandlerMethodValidationExceptionShouldReturnBadRequest() {
+    MethodValidationResult methodValidationResult = mock(MethodValidationResult.class);
+    ParameterValidationResult paramResult = mock(ParameterValidationResult.class);
+    MethodParameter methodParam = mock(MethodParameter.class);
+    MessageSourceResolvable error = mock(MessageSourceResolvable.class);
+    when(methodParam.getParameterName()).thenReturn("paramName");
+    when(paramResult.getMethodParameter()).thenReturn(methodParam);
+    when(error.getDefaultMessage()).thenReturn("must not be null");
+    when(paramResult.getResolvableErrors()).thenReturn(List.of(error));
+    when(methodValidationResult.getParameterValidationResults()).thenReturn(List.of(paramResult));
+
+    HandlerMethodValidationException exception = new HandlerMethodValidationException(
+        methodValidationResult);
+
+    ResponseEntity<Object> response = underTest.handleHandlerMethodValidationException(exception,
+        HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class)
+    );
+
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAuthTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAuthTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerAuthTest {
+
+  @InjectMocks
+  private EnduranceTrioExceptionHandlerAuth underTest;
+
+  @Test
+  void authExceptionShouldReturn401() {
+    AuthenticationException exception = new BadCredentialsException("Invalid credentials");
+
+    ResponseEntity<EnduranceTrioResponse<String>> response = underTest.authException(exception);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals(401, response.getBody().status());
+    assertEquals("Unauthorized", response.getBody().reason());
+  }
+
+  @Test
+  void accessDeniedExceptionShouldReturn403() {
+    AccessDeniedException exception = new AccessDeniedException("Access denied");
+
+    ResponseEntity<EnduranceTrioResponse<String>> response = underTest.handleAuthorizationException(
+        exception);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    assertEquals(403, response.getBody().status());
+    assertEquals("Forbidden", response.getBody().reason());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAuthTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerAuthTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerAuthTest {
+
+  @InjectMocks
+  private EnduranceTrioExceptionHandlerAuth underTest;
+
+  @Test
+  void authExceptionShouldReturn401() {
+    AuthenticationException exception = new BadCredentialsException("Invalid credentials");
+
+    ResponseEntity<EnduranceTrioResponse<String>> response = underTest.authException(exception);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+    assertEquals(401, response.getBody().status());
+    assertEquals("Unauthorized", response.getBody().reason());
+  }
+
+  @Test
+  void accessDeniedExceptionShouldReturn403() {
+    AccessDeniedException exception = new AccessDeniedException("Access denied");
+
+    ResponseEntity<EnduranceTrioResponse<String>> response = underTest.handleAuthorizationException(
+        exception);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    assertEquals(403, response.getBody().status());
+    assertEquals("Forbidden", response.getBody().reason());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerWebTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/handler/EnduranceTrioExceptionHandlerWebTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.service.MessageService;
+import com.endurancetrio.app.config.AppProperties;
+import com.endurancetrio.business.common.dto.ErrorDTO;
+import com.endurancetrio.business.common.exception.EnduranceTrioError;
+import com.endurancetrio.business.common.exception.EnduranceTrioException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.ModelAndView;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioExceptionHandlerWebTest {
+
+  @Mock
+  private MessageService messageService;
+
+  @Mock
+  private AppProperties appProperties;
+
+  @Mock
+  private AppProperties.OpenGraph openGraph;
+
+  @Mock
+  private AppProperties.Social social;
+
+  @Mock
+  private AppProperties.Google google;
+
+  @Mock
+  private AppProperties.KoFi kofi;
+
+  private EnduranceTrioExceptionHandlerWeb underTest;
+
+  private HttpServletRequest request;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new EnduranceTrioExceptionHandlerWeb(messageService, appProperties);
+    request = mock(HttpServletRequest.class);
+
+    when(appProperties.getOpenGraph()).thenReturn(openGraph);
+    when(appProperties.getSocial()).thenReturn(social);
+    when(appProperties.getKoFi()).thenReturn(kofi);
+    when(appProperties.getGoogle()).thenReturn(google);
+    when(appProperties.getCopyrightYear()).thenReturn("2026");
+    when(appProperties.getVersion()).thenReturn("0.4.0");
+    when(openGraph.getDefaultImg()).thenReturn("/img/endurancetrio-open-graph.png");
+    when(openGraph.getDefaultImgWidth()).thenReturn(1200);
+    when(openGraph.getDefaultImgHeight()).thenReturn(628);
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/en/events"));
+    when(request.getRequestURI()).thenReturn("/en/events");
+  }
+
+  @Test
+  void handleEnduranceTrioExceptionShouldReturnNotFound() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.NOT_FOUND));
+
+    when(messageService.getMessage(eq("page.error.404.metadata.title"), any(), any())).thenReturn(
+        "Page Not Found");
+    when(messageService.getMessage(eq("page.error.404.metadata.description"), any(),
+        any()
+    )).thenReturn(
+        "Not found");
+
+    ModelAndView result = underTest.handleEnduranceTrioException(exception, request);
+
+    assertNotNull(result);
+    assertEquals("error/404", result.getViewName());
+    assertEquals("The requested resource was not found", result.getModel().get("message"));
+  }
+
+  @Test
+  void handleEnduranceTrioExceptionShouldReturnForbidden() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(EnduranceTrioError.FORBIDDEN));
+
+    when(messageService.getMessage(eq("page.error.403.metadata.title"), any(), any())).thenReturn(
+        "Forbidden");
+    when(messageService.getMessage(eq("page.error.403.metadata.description"), any(),
+        any()
+    )).thenReturn(
+        "Access denied");
+
+    ModelAndView result = underTest.handleEnduranceTrioException(exception, request);
+
+    assertNotNull(result);
+    assertEquals("error/403", result.getViewName());
+  }
+
+  @Test
+  void handleEnduranceTrioExceptionShouldReturnInternalServerErrorForUnknownCode() {
+    EnduranceTrioException exception = new EnduranceTrioException(
+        new ErrorDTO(999, "Unknown", "Unknown error"));
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn(
+        "Error occurred");
+
+    ModelAndView result = underTest.handleEnduranceTrioException(exception, request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+  }
+
+  @Test
+  void handleEnduranceTrioExceptionShouldIncludeErrorsInModel() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "invalid field");
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn(
+        "Error");
+
+    ModelAndView result = underTest.handleEnduranceTrioException(exception, request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertNotNull(result.getModel().get("errors"));
+  }
+
+  @Test
+  void handleDataIntegrityShouldReturnConflict() {
+    DataIntegrityViolationException ex = new DataIntegrityViolationException(
+        "constraint violation");
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn(
+        "Error");
+
+    ModelAndView result = underTest.handleDataIntegrity(ex, request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertEquals(HttpStatus.CONFLICT.value(), result.getModel().get("status"));
+    assertEquals("A conflict occurred with the current state of the resource",
+        result.getModel().get("message")
+    );
+  }
+
+  @Test
+  void handleUnhandledExceptionShouldReturnInternalServerError() {
+    Exception ex = new RuntimeException("Unexpected error");
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn(
+        "Error");
+
+    ModelAndView result = underTest.handleUnhandledException(ex, request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), result.getModel().get("status"));
+    assertEquals("An internal server error occurred", result.getModel().get("message"));
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/entrypoint/EnduranceTrioAuthEntryPointTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/entrypoint/EnduranceTrioAuthEntryPointTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.entrypoint;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthEntryPointTest {
+
+  @Mock
+  private HandlerExceptionResolver resolver;
+
+  @InjectMocks
+  private EnduranceTrioAuthEntryPoint underTest;
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+  }
+
+  @Test
+  void shouldDelegateToHandlerExceptionResolver() {
+    AuthenticationException authException = new BadCredentialsException("Invalid key");
+
+    underTest.commence(request, response, authException);
+
+    verify(resolver).resolveException(request, response, null, authException);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/entrypoint/EnduranceTrioAuthEntryPointTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/entrypoint/EnduranceTrioAuthEntryPointTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.entrypoint;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthEntryPointTest {
+
+  @Mock
+  private HandlerExceptionResolver resolver;
+
+  @InjectMocks
+  private EnduranceTrioAuthEntryPoint underTest;
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+  }
+
+  @Test
+  void shouldDelegateToHandlerExceptionResolver() {
+    AuthenticationException authException = new BadCredentialsException("Invalid key");
+
+    underTest.commence(request, response, authException);
+
+    verify(resolver).resolveException(request, response, null, authException);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/filter/EnduranceTrioAuthFilterTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/filter/EnduranceTrioAuthFilterTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.security.token.EnduranceTrioAuthToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthFilterTest {
+
+  private static final String VALID_KEY = "validKey123";
+  private static final String OWNER = "testOwner";
+
+  @Mock
+  private AuthenticationManager authManager;
+
+  @Mock
+  private AuthenticationEntryPoint entryPoint;
+
+  @InjectMocks
+  private EnduranceTrioAuthFilter underTest;
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private FilterChain filterChain;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    response = new MockHttpServletResponse();
+    filterChain = mock(FilterChain.class);
+  }
+
+  @Test
+  void validRequestShouldAuthenticate() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(OWNER);
+
+    Authentication authResult = mock(Authentication.class);
+    when(authResult.isAuthenticated()).thenReturn(true);
+    when(authManager.authenticate(any(EnduranceTrioAuthToken.class))).thenReturn(authResult);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager).authenticate(any(EnduranceTrioAuthToken.class));
+    verify(filterChain).doFilter(request, response);
+    verify(entryPoint, never()).commence(any(), any(), any());
+  }
+
+  @Test
+  void missingAuthHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void missingOwnerHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void invalidAuthHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Invalid header");
+    when(request.getHeader("ET-Owner")).thenReturn(OWNER);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void blankOwnerHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn("");
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void authenticationFailureShouldCallEntryPoint() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(OWNER);
+
+    BadCredentialsException exception = new BadCredentialsException("Invalid key");
+    when(authManager.authenticate(any(EnduranceTrioAuthToken.class))).thenThrow(exception);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(entryPoint).commence(request, response, exception);
+    verify(filterChain, never()).doFilter(request, response);
+  }
+
+  @Test
+  void lowercaseHeadersShouldBeChecked() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    when(request.getHeader("authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+    when(request.getHeader("et-owner")).thenReturn(OWNER);
+
+    Authentication authResult = mock(Authentication.class);
+    when(authResult.isAuthenticated()).thenReturn(true);
+    when(authManager.authenticate(any(EnduranceTrioAuthToken.class))).thenReturn(authResult);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager).authenticate(any(EnduranceTrioAuthToken.class));
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/filter/EnduranceTrioAuthFilterTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/filter/EnduranceTrioAuthFilterTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.security.token.EnduranceTrioAuthToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthFilterTest {
+
+  private static final String VALID_KEY = "validKey123";
+  private static final String OWNER = "testOwner";
+
+  @Mock
+  private AuthenticationManager authManager;
+
+  @Mock
+  private AuthenticationEntryPoint entryPoint;
+
+  @InjectMocks
+  private EnduranceTrioAuthFilter underTest;
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private FilterChain filterChain;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    response = new MockHttpServletResponse();
+    filterChain = mock(FilterChain.class);
+  }
+
+  @Test
+  void validRequestShouldAuthenticate() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(OWNER);
+
+    Authentication authResult = mock(Authentication.class);
+    when(authResult.isAuthenticated()).thenReturn(true);
+    when(authManager.authenticate(any(EnduranceTrioAuthToken.class))).thenReturn(authResult);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager).authenticate(any(EnduranceTrioAuthToken.class));
+    verify(filterChain).doFilter(request, response);
+    verify(entryPoint, never()).commence(any(), any(), any());
+  }
+
+  @Test
+  void missingAuthHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void missingOwnerHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void invalidAuthHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Invalid header");
+    when(request.getHeader("ET-Owner")).thenReturn(OWNER);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void blankOwnerHeaderShouldSkipAuth() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn("");
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager, never()).authenticate(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void authenticationFailureShouldCallEntryPoint() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(OWNER);
+
+    BadCredentialsException exception = new BadCredentialsException("Invalid key");
+    when(authManager.authenticate(any(EnduranceTrioAuthToken.class))).thenThrow(exception);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(entryPoint).commence(request, response, exception);
+    verify(filterChain, never()).doFilter(request, response);
+  }
+
+  @Test
+  void lowercaseHeadersShouldBeChecked() throws Exception {
+    when(request.getHeader("Authorization")).thenReturn(null);
+    when(request.getHeader("authorization")).thenReturn("Bearer " + VALID_KEY);
+    when(request.getHeader("ET-Owner")).thenReturn(null);
+    when(request.getHeader("et-owner")).thenReturn(OWNER);
+
+    Authentication authResult = mock(Authentication.class);
+    when(authResult.isAuthenticated()).thenReturn(true);
+    when(authManager.authenticate(any(EnduranceTrioAuthToken.class))).thenReturn(authResult);
+
+    underTest.doFilterInternal(request, response, filterChain);
+
+    verify(authManager).authenticate(any(EnduranceTrioAuthToken.class));
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/provider/EnduranceTrioAuthProviderTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/provider/EnduranceTrioAuthProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.security.token.EnduranceTrioAuthToken;
+import com.endurancetrio.business.tracker.service.TrackerAccountService;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthProviderTest {
+
+  private static final String OWNER = "testOwner";
+  private static final String VALID_KEY = "validKey123";
+  private static final String INVALID_KEY = "invalidKey456";
+
+  @Mock
+  private TrackerAccountService trackerAccountService;
+
+  @InjectMocks
+  private EnduranceTrioAuthProvider underTest;
+
+  private EnduranceTrioAuthToken authRequest;
+
+  @BeforeEach
+  void setUp() {
+    authRequest = new EnduranceTrioAuthToken(OWNER, VALID_KEY);
+  }
+
+  @Test
+  void validKeyShouldReturnAuthenticatedToken() {
+    when(trackerAccountService.validateKey(OWNER, VALID_KEY)).thenReturn(true);
+
+    Authentication result = underTest.authenticate(authRequest);
+
+    assertNotNull(result);
+    assertTrue(result.isAuthenticated());
+    assertEquals(OWNER, result.getPrincipal());
+    assertTrue(result.getAuthorities()
+        .stream()
+        .anyMatch(a -> Objects.equals(a.getAuthority(), "ROLE_TRACKER")));
+  }
+
+  @Test
+  void invalidKeyShouldThrowBadCredentials() {
+    EnduranceTrioAuthToken badRequest = new EnduranceTrioAuthToken(OWNER, INVALID_KEY);
+    when(trackerAccountService.validateKey(OWNER, INVALID_KEY)).thenReturn(false);
+
+    assertThrows(BadCredentialsException.class, () -> underTest.authenticate(badRequest));
+  }
+
+  @Test
+  void supportsShouldReturnTrueForEnduranceTrioAuthToken() {
+    assertTrue(underTest.supports(EnduranceTrioAuthToken.class));
+  }
+
+  @Test
+  void supportsShouldReturnFalseForOtherTypes() {
+    assertFalse(underTest.supports(String.class));
+  }
+
+  @Test
+  void authenticatedTokenShouldHaveNoCredentials() {
+    when(trackerAccountService.validateKey(OWNER, VALID_KEY)).thenReturn(true);
+
+    Authentication result = underTest.authenticate(authRequest);
+
+    assertNotNull(result);
+    assertNull(result.getCredentials());
+  }
+
+  private void assertNull(Object credentials) {
+    org.junit.jupiter.api.Assertions.assertNull(credentials);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/provider/EnduranceTrioAuthProviderTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/provider/EnduranceTrioAuthProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.security.token.EnduranceTrioAuthToken;
+import com.endurancetrio.business.tracker.service.TrackerAccountService;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioAuthProviderTest {
+
+  private static final String OWNER = "testOwner";
+  private static final String VALID_KEY = "validKey123";
+  private static final String INVALID_KEY = "invalidKey456";
+
+  @Mock
+  private TrackerAccountService trackerAccountService;
+
+  @InjectMocks
+  private EnduranceTrioAuthProvider underTest;
+
+  private EnduranceTrioAuthToken authRequest;
+
+  @BeforeEach
+  void setUp() {
+    authRequest = new EnduranceTrioAuthToken(OWNER, VALID_KEY);
+  }
+
+  @Test
+  void validKeyShouldReturnAuthenticatedToken() {
+    when(trackerAccountService.validateKey(OWNER, VALID_KEY)).thenReturn(true);
+
+    Authentication result = underTest.authenticate(authRequest);
+
+    assertNotNull(result);
+    assertTrue(result.isAuthenticated());
+    assertEquals(OWNER, result.getPrincipal());
+    assertTrue(result.getAuthorities()
+        .stream()
+        .anyMatch(a -> Objects.equals(a.getAuthority(), "ROLE_TRACKER")));
+  }
+
+  @Test
+  void invalidKeyShouldThrowBadCredentials() {
+    EnduranceTrioAuthToken badRequest = new EnduranceTrioAuthToken(OWNER, INVALID_KEY);
+    when(trackerAccountService.validateKey(OWNER, INVALID_KEY)).thenReturn(false);
+
+    assertThrows(BadCredentialsException.class, () -> underTest.authenticate(badRequest));
+  }
+
+  @Test
+  void supportsShouldReturnTrueForEnduranceTrioAuthToken() {
+    assertTrue(underTest.supports(EnduranceTrioAuthToken.class));
+  }
+
+  @Test
+  void supportsShouldReturnFalseForOtherTypes() {
+    assertFalse(underTest.supports(String.class));
+  }
+
+  @Test
+  void authenticatedTokenShouldHaveNoCredentials() {
+    when(trackerAccountService.validateKey(OWNER, VALID_KEY)).thenReturn(true);
+
+    Authentication result = underTest.authenticate(authRequest);
+
+    assertNotNull(result);
+    assertNull(result.getCredentials());
+  }
+
+  private void assertNull(Object credentials) {
+    org.junit.jupiter.api.Assertions.assertNull(credentials);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/token/EnduranceTrioAuthTokenTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/token/EnduranceTrioAuthTokenTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class EnduranceTrioAuthTokenTest {
+
+  private static final String OWNER = "testOwner";
+  private static final String KEY = "testKey123";
+
+  @Test
+  void unauthenticatedConstructorShouldSetPrincipalAndCredentials() {
+    EnduranceTrioAuthToken token = new EnduranceTrioAuthToken(OWNER, KEY);
+
+    assertEquals(OWNER, token.getPrincipal());
+    assertEquals(KEY, token.getCredentials());
+    assertFalse(token.isAuthenticated());
+  }
+
+  @Test
+  void authenticatedConstructorShouldSetPrincipalAndAuthorities() {
+    EnduranceTrioAuthToken token = new EnduranceTrioAuthToken(OWNER,
+        List.of(new SimpleGrantedAuthority("ROLE_TRACKER"))
+    );
+
+    assertEquals(OWNER, token.getPrincipal());
+    assertNull(token.getCredentials());
+    assertTrue(token.isAuthenticated());
+  }
+
+  @Test
+  void tokensWithSameFieldsShouldBeEqual() {
+    EnduranceTrioAuthToken token1 = new EnduranceTrioAuthToken(OWNER, KEY);
+    EnduranceTrioAuthToken token2 = new EnduranceTrioAuthToken(OWNER, KEY);
+
+    assertEquals(token1, token2);
+    assertEquals(token1.hashCode(), token2.hashCode());
+  }
+
+  @Test
+  void tokensWithDifferentOwnersShouldNotBeEqual() {
+    EnduranceTrioAuthToken token1 = new EnduranceTrioAuthToken(OWNER, KEY);
+    EnduranceTrioAuthToken token2 = new EnduranceTrioAuthToken("otherOwner", KEY);
+
+    assertNotEquals(token1, token2);
+  }
+
+  @Test
+  void tokensWithDifferentCredentialsShouldNotBeEqual() {
+    EnduranceTrioAuthToken token1 = new EnduranceTrioAuthToken(OWNER, KEY);
+    EnduranceTrioAuthToken token2 = new EnduranceTrioAuthToken(OWNER, "otherKey");
+
+    assertNotEquals(token1, token2);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/token/EnduranceTrioAuthTokenTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/security/token/EnduranceTrioAuthTokenTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.security.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class EnduranceTrioAuthTokenTest {
+
+  private static final String OWNER = "testOwner";
+  private static final String KEY = "testKey123";
+
+  @Test
+  void unauthenticatedConstructorShouldSetPrincipalAndCredentials() {
+    EnduranceTrioAuthToken token = new EnduranceTrioAuthToken(OWNER, KEY);
+
+    assertEquals(OWNER, token.getPrincipal());
+    assertEquals(KEY, token.getCredentials());
+    assertFalse(token.isAuthenticated());
+  }
+
+  @Test
+  void authenticatedConstructorShouldSetPrincipalAndAuthorities() {
+    EnduranceTrioAuthToken token = new EnduranceTrioAuthToken(OWNER,
+        List.of(new SimpleGrantedAuthority("ROLE_TRACKER"))
+    );
+
+    assertEquals(OWNER, token.getPrincipal());
+    assertNull(token.getCredentials());
+    assertTrue(token.isAuthenticated());
+  }
+
+  @Test
+  void tokensWithSameFieldsShouldBeEqual() {
+    EnduranceTrioAuthToken token1 = new EnduranceTrioAuthToken(OWNER, KEY);
+    EnduranceTrioAuthToken token2 = new EnduranceTrioAuthToken(OWNER, KEY);
+
+    assertEquals(token1, token2);
+    assertEquals(token1.hashCode(), token2.hashCode());
+  }
+
+  @Test
+  void tokensWithDifferentOwnersShouldNotBeEqual() {
+    EnduranceTrioAuthToken token1 = new EnduranceTrioAuthToken(OWNER, KEY);
+    EnduranceTrioAuthToken token2 = new EnduranceTrioAuthToken("otherOwner", KEY);
+
+    assertNotEquals(token1, token2);
+  }
+
+  @Test
+  void tokensWithDifferentCredentialsShouldNotBeEqual() {
+    EnduranceTrioAuthToken token1 = new EnduranceTrioAuthToken(OWNER, KEY);
+    EnduranceTrioAuthToken token2 = new EnduranceTrioAuthToken(OWNER, "otherKey");
+
+    assertNotEquals(token1, token2);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/utils/ErrorPageUtilsTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/utils/ErrorPageUtilsTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.model.PageMetadata;
+import com.endurancetrio.app.common.service.MessageService;
+import com.endurancetrio.app.config.AppProperties;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.ModelAndView;
+
+class ErrorPageUtilsTest {
+
+  private static final String ERROR_VIEW_PREFIX = "error/";
+  private static final Locale LOCALE_PORTUGUESE = Locale.of("pt", "PT");
+
+  @Test
+  void errorViewShouldReturn403() {
+    assertEquals(ERROR_VIEW_PREFIX + "403", ErrorPageUtils.errorView(403));
+  }
+
+  @Test
+  void errorViewShouldReturn404() {
+    assertEquals(ERROR_VIEW_PREFIX + "404", ErrorPageUtils.errorView(404));
+  }
+
+  @Test
+  void errorViewShouldReturn500ForServerError() {
+    assertEquals(ERROR_VIEW_PREFIX + "500", ErrorPageUtils.errorView(500));
+  }
+
+  @Test
+  void errorViewShouldReturn500ForUnknownStatus() {
+    assertEquals(ERROR_VIEW_PREFIX + "500", ErrorPageUtils.errorView(999));
+  }
+
+  @Test
+  void createErrorPageMetadataShouldReturnMetadataFor403() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+
+    when(messageService.getMessage("page.error.403.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Access Denied - EnduranceTrio");
+    when(messageService.getMessage("page.error.403.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("You don't have permission to access this page");
+
+    PageMetadata result = ErrorPageUtils.createErrorPageMetadata(403, request, Locale.ENGLISH,
+        messageService, appProperties
+    );
+
+    assertNotNull(result);
+    assertEquals("Access Denied - EnduranceTrio", result.getTitle());
+    assertEquals("You don't have permission to access this page", result.getDescription());
+  }
+
+  @Test
+  void createErrorPageMetadataShouldReturnMetadataFor404() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+
+    when(messageService.getMessage("page.error.404.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Page Not Found - EnduranceTrio");
+    when(messageService.getMessage("page.error.404.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("The requested page was not found");
+
+    PageMetadata result = ErrorPageUtils.createErrorPageMetadata(404, request, Locale.ENGLISH,
+        messageService, appProperties
+    );
+
+    assertNotNull(result);
+    assertEquals("Page Not Found - EnduranceTrio", result.getTitle());
+    assertEquals("The requested page was not found", result.getDescription());
+  }
+
+  @Test
+  void createErrorPageMetadataShouldDefaultTo500() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+
+    when(messageService.getMessage("page.error.500.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Server Error - EnduranceTrio");
+    when(messageService.getMessage("page.error.500.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("An internal server error occurred");
+
+    PageMetadata result = ErrorPageUtils.createErrorPageMetadata(500, request, Locale.ENGLISH,
+        messageService, appProperties
+    );
+
+    assertNotNull(result);
+    assertEquals("Server Error - EnduranceTrio", result.getTitle());
+    assertEquals("An internal server error occurred", result.getDescription());
+  }
+
+  @Test
+  void createErrorPageMetadataShouldDefaultTo500ForUnknownCode() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+
+    when(messageService.getMessage("page.error.500.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Server Error - EnduranceTrio");
+    when(messageService.getMessage("page.error.500.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("An internal server error occurred");
+
+    PageMetadata result = ErrorPageUtils.createErrorPageMetadata(999, request, Locale.ENGLISH,
+        messageService, appProperties
+    );
+
+    assertNotNull(result);
+    assertEquals("Server Error - EnduranceTrio", result.getTitle());
+  }
+
+  @Test
+  void buildErrorModelAndViewShouldReturnModelWithStandardAttributes() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+
+    when(messageService.getMessage("page.error.404.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Page Not Found - EnduranceTrio");
+    when(messageService.getMessage("page.error.404.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("The requested page was not found");
+
+    ModelAndView result = ErrorPageUtils.buildErrorModelAndView(HttpStatus.NOT_FOUND,
+        "Resource not found", null, request, messageService, appProperties
+    );
+
+    assertNotNull(result);
+    assertEquals("error/404", result.getViewName());
+    assertEquals("en", result.getModel().get("language"));
+    assertNotNull(result.getModel().get("metadata"));
+    assertEquals(404, result.getModel().get("status"));
+    assertEquals("Not Found", result.getModel().get("reason"));
+    assertEquals("Resource not found", result.getModel().get("message"));
+    assertNull(result.getModel().get("errors"));
+  }
+
+  @Test
+  void buildErrorModelAndViewShouldIncludeErrorsWhenProvided() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+    var errors = List.of(
+        new com.endurancetrio.business.common.dto.ErrorDTO(
+            com.endurancetrio.business.common.exception.EnduranceTrioError.CONFLICT, "duplicate key"
+        )
+    );
+
+    when(messageService.getMessage("page.error.500.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Server Error - EnduranceTrio");
+    when(messageService.getMessage("page.error.500.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("An internal server error occurred");
+
+    ModelAndView result = ErrorPageUtils.buildErrorModelAndView(HttpStatus.CONFLICT, "Conflict",
+        errors, request, messageService, appProperties
+    );
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertNotNull(result.getModel().get("errors"));
+    assertEquals(errors, result.getModel().get("errors"));
+  }
+
+  @Test
+  void buildErrorModelAndViewShouldResolveEnglishLocale() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = createRequest("http://localhost:8080/en/events", "/en/events");
+
+    when(messageService.getMessage("page.error.500.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Server Error - EnduranceTrio");
+    when(messageService.getMessage("page.error.500.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("An internal server error occurred");
+
+    ModelAndView result = ErrorPageUtils.buildErrorModelAndView(HttpStatus.INTERNAL_SERVER_ERROR,
+        "error", null, request, messageService, appProperties
+    );
+
+    assertEquals("en", result.getModel().get("language"));
+  }
+
+  @Test
+  void buildErrorModelAndViewShouldResolvePortugueseLocaleFromErrorRequestUri() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/pt/events/404");
+    when(request.getRequestURI()).thenReturn("/error");
+    when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURL()).thenReturn(
+        new StringBuffer("http://localhost:8080/error"));
+
+    when(messageService.getMessage("page.error.500.metadata.title", null, LOCALE_PORTUGUESE)).thenReturn(
+        "Erro do Servidor - EnduranceTrio");
+    when(messageService.getMessage("page.error.500.metadata.description", null,
+        LOCALE_PORTUGUESE
+    )).thenReturn("Ocorreu um erro interno do servidor");
+
+    ModelAndView result = ErrorPageUtils.buildErrorModelAndView(HttpStatus.INTERNAL_SERVER_ERROR,
+        "erro", null, request, messageService, appProperties
+    );
+
+    assertEquals("pt", result.getModel().get("language"));
+  }
+
+  @Test
+  void buildErrorModelAndViewShouldResolveEnglishWithContextPath() {
+    MessageService messageService = mock(MessageService.class);
+    AppProperties appProperties = createAppProperties();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/myapp/en/events");
+    when(request.getContextPath()).thenReturn("/myapp");
+    when(request.getRequestURI()).thenReturn("/error");
+    when(request.getRequestURL()).thenReturn(
+        new StringBuffer("http://localhost:8080/error"));
+
+    when(messageService.getMessage("page.error.500.metadata.title", null, Locale.ENGLISH)).thenReturn(
+        "Server Error - EnduranceTrio");
+    when(messageService.getMessage("page.error.500.metadata.description", null,
+        Locale.ENGLISH
+    )).thenReturn("Error");
+
+    ModelAndView result = ErrorPageUtils.buildErrorModelAndView(HttpStatus.INTERNAL_SERVER_ERROR,
+        "error", null, request, messageService, appProperties
+    );
+
+    assertEquals("en", result.getModel().get("language"));
+  }
+
+  @Test
+  void constructorShouldThrow() {
+    assertThrows(InvocationTargetException.class, () -> {
+      var constructor = ErrorPageUtils.class.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      constructor.newInstance();
+    });
+  }
+
+  private static AppProperties createAppProperties() {
+    AppProperties appProperties = new AppProperties();
+    appProperties.getOpenGraph().setDefaultImg("/img/endurancetrio-open-graph.png");
+    appProperties.getOpenGraph().setDefaultImgWidth(1200);
+    appProperties.getOpenGraph().setDefaultImgHeight(628);
+    appProperties.getSocial().setFacebookPageId("1692877750958091");
+    appProperties.getSocial().setTwitterSite("@EnduranceTrio");
+    appProperties.getGoogle().setAdsenseId("ca-pub-test");
+    appProperties.getKoFi().setUserId("test-kofi");
+    appProperties.setCopyrightYear("2026");
+    appProperties.setVersion("0.4.0");
+    return appProperties;
+  }
+
+  private static HttpServletRequest createRequest(String url, String uri) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRequestURL()).thenReturn(new StringBuffer(url));
+    when(request.getRequestURI()).thenReturn(uri);
+    return request;
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/web/EnduranceTrioErrorControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/web/EnduranceTrioErrorControllerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED IS AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.service.MessageService;
+import com.endurancetrio.app.config.AppProperties;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.ModelAndView;
+
+@ExtendWith(MockitoExtension.class)
+class EnduranceTrioErrorControllerTest {
+
+  @Mock
+  private MessageService messageService;
+
+  @Mock
+  private AppProperties appProperties;
+
+  @Mock
+  private AppProperties.OpenGraph openGraph;
+
+  @Mock
+  private AppProperties.Social social;
+
+  @Mock
+  private AppProperties.Google google;
+
+  @Mock
+  private AppProperties.KoFi kofi;
+
+  private EnduranceTrioErrorController underTest;
+
+  private HttpServletRequest request;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new EnduranceTrioErrorController(messageService, appProperties);
+    request = mock(HttpServletRequest.class);
+
+    when(appProperties.getOpenGraph()).thenReturn(openGraph);
+    when(appProperties.getSocial()).thenReturn(social);
+    when(appProperties.getKoFi()).thenReturn(kofi);
+    when(appProperties.getGoogle()).thenReturn(google);
+    when(appProperties.getCopyrightYear()).thenReturn("2026");
+    when(appProperties.getVersion()).thenReturn("0.4.0");
+    when(openGraph.getDefaultImg()).thenReturn("/img/endurancetrio-open-graph.png");
+    when(openGraph.getDefaultImgWidth()).thenReturn(1200);
+    when(openGraph.getDefaultImgHeight()).thenReturn(628);
+    when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/error"));
+    when(request.getRequestURI()).thenReturn("/error");
+  }
+
+  @Test
+  void handleErrorShouldReturn404Page() {
+    when(request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).thenReturn(404);
+    when(request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).thenReturn("Not Found");
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn(
+        "/en/events/unknown");
+
+    when(messageService.getMessage(eq("page.error.404.metadata.title"), any(), any())).thenReturn(
+        "Page Not Found");
+    when(messageService.getMessage(eq("page.error.404.metadata.description"), any(),
+        any()
+    )).thenReturn("Not found");
+
+    ModelAndView result = underTest.handleError(request);
+
+    assertNotNull(result);
+    assertEquals("error/404", result.getViewName());
+    assertEquals(404, result.getModel().get("status"));
+    assertEquals("Not Found", result.getModel().get("message"));
+    assertEquals("en", result.getModel().get("language"));
+  }
+
+  @Test
+  void handleErrorShouldReturn403Page() {
+    when(request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).thenReturn(403);
+    when(request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).thenReturn("Forbidden");
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/pt/events/admin");
+
+    when(messageService.getMessage(eq("page.error.403.metadata.title"), any(), any())).thenReturn(
+        "Forbidden");
+    when(messageService.getMessage(eq("page.error.403.metadata.description"), any(),
+        any()
+    )).thenReturn("Access denied");
+
+    ModelAndView result = underTest.handleError(request);
+
+    assertNotNull(result);
+    assertEquals("error/403", result.getViewName());
+    assertEquals(403, result.getModel().get("status"));
+    assertEquals("pt", result.getModel().get("language"));
+  }
+
+  @Test
+  void handleErrorShouldReturn500PageForServerError() {
+    when(request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).thenReturn(500);
+    when(request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).thenReturn("Internal error");
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/en/events");
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn("Error occurred");
+
+    ModelAndView result = underTest.handleError(request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertEquals(500, result.getModel().get("status"));
+  }
+
+  @Test
+  void handleErrorShouldDefaultTo500WhenNoStatusCode() {
+    when(request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).thenReturn(null);
+    when(request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).thenReturn(null);
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/en/events");
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn("Error");
+
+    ModelAndView result = underTest.handleError(request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertEquals(500, result.getModel().get("status"));
+    assertEquals("An internal server error occurred", result.getModel().get("message"));
+  }
+
+  @Test
+  void handleErrorShouldUseDefaultMessageWhenNull() {
+    when(request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).thenReturn(500);
+    when(request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).thenReturn(null);
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/en/events");
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn("Error");
+
+    ModelAndView result = underTest.handleError(request);
+
+    assertNotNull(result);
+    assertEquals("An internal server error occurred", result.getModel().get("message"));
+  }
+
+  @Test
+  void handleErrorShouldDefaultTo500WhenUnresolvableStatusCode() {
+    when(request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE)).thenReturn(999);
+    when(request.getAttribute(RequestDispatcher.ERROR_MESSAGE)).thenReturn("Weird error");
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/en/events");
+
+    when(messageService.getMessage(eq("page.error.500.metadata.title"), any(), any())).thenReturn(
+        "Server Error");
+    when(messageService.getMessage(eq("page.error.500.metadata.description"), any(),
+        any()
+    )).thenReturn("Error");
+
+    ModelAndView result = underTest.handleError(request);
+
+    assertNotNull(result);
+    assertEquals("error/500", result.getViewName());
+    assertEquals(500, result.getModel().get("status"));
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/AppSecurityConfigTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/AppSecurityConfigTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.security.entrypoint.EnduranceTrioAuthEntryPoint;
+import com.endurancetrio.app.common.security.provider.EnduranceTrioAuthProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@ExtendWith(MockitoExtension.class)
+class AppSecurityConfigTest {
+
+  @Mock
+  private EnduranceTrioAuthProvider authProvider;
+
+  @Mock
+  private EnduranceTrioAuthEntryPoint entryPoint;
+
+  @Test
+  void corsConfigurationSourceWithNullOriginsShouldReturnNonNullSource() {
+    AppSecurityConfig config = new AppSecurityConfig(null, authProvider, entryPoint);
+
+    assertNotNull(config.corsConfigurationSource());
+  }
+
+  @Test
+  void corsConfigurationSourceWithEmptyOriginsShouldReturnNonNullSource() {
+    AppSecurityConfig config = new AppSecurityConfig("", authProvider, entryPoint);
+
+    assertNotNull(config.corsConfigurationSource());
+  }
+
+  @Test
+  void corsConfigurationSourceShouldConfigureAllowedOrigins() {
+    AppSecurityConfig config = new AppSecurityConfig("http://localhost:3000", authProvider,
+        entryPoint
+    );
+    CorsConfigurationSource source = config.corsConfigurationSource();
+
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig);
+    assertNotNull(corsConfig.getAllowedOrigins());
+    assertTrue(corsConfig.getAllowedOrigins().contains("http://localhost:3000"));
+  }
+
+  @Test
+  void corsConfigurationSourceShouldParseAndTrimMultipleOrigins() {
+    AppSecurityConfig config = new AppSecurityConfig(" https://a.com , https://b.com ", authProvider,
+        entryPoint
+    );
+    CorsConfigurationSource source = config.corsConfigurationSource();
+
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig);
+    assertNotNull(corsConfig.getAllowedOrigins());
+    assertTrue(corsConfig.getAllowedOrigins().contains("https://a.com"));
+    assertTrue(corsConfig.getAllowedOrigins().contains("https://b.com"));
+  }
+
+  @Test
+  void corsConfigurationSourceShouldConfigureCorsSettings() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    CorsConfigurationSource source = config.corsConfigurationSource();
+
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig);
+    assertNotNull(corsConfig.getAllowedMethods());
+    assertTrue(corsConfig.getAllowedMethods().containsAll(
+        List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")));
+    assertNotNull(corsConfig.getAllowedHeaders());
+    assertTrue(corsConfig.getAllowedHeaders().contains("*"));
+    assertEquals(Boolean.TRUE, corsConfig.getAllowCredentials());
+  }
+
+  @Test
+  void authenticationManagerShouldReturnProviderManager() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+
+    AuthenticationManager manager = config.authenticationManager();
+
+    assertNotNull(manager);
+    assertInstanceOf(ProviderManager.class, manager);
+  }
+
+  @Test
+  void authenticationFilterShouldReturnNonNullFilter() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+
+    assertNotNull(config.authenticationFilter());
+  }
+
+  @Test
+  void securityFilterChainAPIShouldBuildSuccessfully() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    HttpSecurity http = mock(HttpSecurity.class, RETURNS_SELF);
+    DefaultSecurityFilterChain chain = mock(DefaultSecurityFilterChain.class);
+    when(http.build()).thenReturn(chain);
+
+    assertSame(chain, config.securityFilterChainAPI(http));
+  }
+
+  @Test
+  void securityFilterChainWebShouldBuildSuccessfully() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    HttpSecurity http = mock(HttpSecurity.class, RETURNS_SELF);
+    DefaultSecurityFilterChain chain = mock(DefaultSecurityFilterChain.class);
+    when(http.build()).thenReturn(chain);
+
+    assertSame(chain, config.securityFilterChainWeb(http));
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/AppSecurityConfigTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/AppSecurityConfigTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.security.entrypoint.EnduranceTrioAuthEntryPoint;
+import com.endurancetrio.app.common.security.provider.EnduranceTrioAuthProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@ExtendWith(MockitoExtension.class)
+class AppSecurityConfigTest {
+
+  @Mock
+  private EnduranceTrioAuthProvider authProvider;
+
+  @Mock
+  private EnduranceTrioAuthEntryPoint entryPoint;
+
+  @Test
+  void corsConfigurationSourceWithNullOriginsShouldReturnNonNullSource() {
+    AppSecurityConfig config = new AppSecurityConfig(null, authProvider, entryPoint);
+
+    assertNotNull(config.corsConfigurationSource());
+  }
+
+  @Test
+  void corsConfigurationSourceWithEmptyOriginsShouldReturnNonNullSource() {
+    AppSecurityConfig config = new AppSecurityConfig("", authProvider, entryPoint);
+
+    assertNotNull(config.corsConfigurationSource());
+  }
+
+  @Test
+  void corsConfigurationSourceShouldConfigureAllowedOrigins() {
+    AppSecurityConfig config = new AppSecurityConfig("http://localhost:3000", authProvider,
+        entryPoint
+    );
+    CorsConfigurationSource source = config.corsConfigurationSource();
+
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig);
+    assertNotNull(corsConfig.getAllowedOrigins());
+    assertTrue(corsConfig.getAllowedOrigins().contains("http://localhost:3000"));
+  }
+
+  @Test
+  void corsConfigurationSourceShouldParseAndTrimMultipleOrigins() {
+    AppSecurityConfig config = new AppSecurityConfig(" https://a.com , https://b.com ", authProvider,
+        entryPoint
+    );
+    CorsConfigurationSource source = config.corsConfigurationSource();
+
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig);
+    assertNotNull(corsConfig.getAllowedOrigins());
+    assertTrue(corsConfig.getAllowedOrigins().contains("https://a.com"));
+    assertTrue(corsConfig.getAllowedOrigins().contains("https://b.com"));
+  }
+
+  @Test
+  void corsConfigurationSourceShouldConfigureCorsSettings() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    CorsConfigurationSource source = config.corsConfigurationSource();
+
+    CorsConfiguration corsConfig = source.getCorsConfiguration(
+        new MockHttpServletRequest("GET", "/api/test"));
+
+    assertNotNull(corsConfig);
+    assertNotNull(corsConfig.getAllowedMethods());
+    assertTrue(corsConfig.getAllowedMethods().containsAll(
+        List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")));
+    assertNotNull(corsConfig.getAllowedHeaders());
+    assertTrue(corsConfig.getAllowedHeaders().contains("*"));
+    assertEquals(Boolean.TRUE, corsConfig.getAllowCredentials());
+  }
+
+  @Test
+  void authenticationManagerShouldReturnProviderManager() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+
+    AuthenticationManager manager = config.authenticationManager();
+
+    assertNotNull(manager);
+    assertInstanceOf(ProviderManager.class, manager);
+  }
+
+  @Test
+  void authenticationFilterShouldReturnNonNullFilter() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+
+    assertNotNull(config.authenticationFilter());
+  }
+
+  @Test
+  void securityFilterChainAPIShouldBuildSuccessfully() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    HttpSecurity http = mock(HttpSecurity.class, RETURNS_SELF);
+    DefaultSecurityFilterChain chain = mock(DefaultSecurityFilterChain.class);
+    when(http.build()).thenReturn(chain);
+
+    assertSame(chain, config.securityFilterChainAPI(http));
+  }
+
+  @Test
+  void securityFilterChainWebShouldBuildSuccessfully() {
+    AppSecurityConfig config = new AppSecurityConfig("*", authProvider, entryPoint);
+    HttpSecurity http = mock(HttpSecurity.class, RETURNS_SELF);
+    DefaultSecurityFilterChain chain = mock(DefaultSecurityFilterChain.class);
+    when(http.build()).thenReturn(chain);
+
+    assertSame(chain, config.securityFilterChainWeb(http));
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/LocaleRedirectFilterTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/LocaleRedirectFilterTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED IS AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LocaleRedirectFilterTest {
+
+  private LocaleRedirectFilter underTest;
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private FilterChain filterChain;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new LocaleRedirectFilter();
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+    filterChain = mock(FilterChain.class);
+  }
+
+  @Test
+  void shouldPassStaticCssRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/css/styles.css");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(response, never()).sendRedirect(any());
+  }
+
+  @Test
+  void shouldPassStaticJsRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/js/app.js");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassStaticImgRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/img/logo.png");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassWebjarsRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/webjars/bootstrap/5.3.0/js/bootstrap.min.js");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassFaviconRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/favicon.ico");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassApiRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/api/tracker/v1/devices");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassSwaggerUiRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/swagger-ui/index.html");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassApiDocsRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/v3/api-docs");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldRedirectToEnglishWhenNoLocaleInPathAndNoAcceptLanguage() throws Exception {
+    when(request.getRequestURI()).thenReturn("/events");
+    when(request.getHeader("Accept-Language")).thenReturn(null);
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(response).sendRedirect("/en/events");
+    verify(filterChain, never()).doFilter(any(), any());
+  }
+
+  @Test
+  void shouldRedirectToPortugueseWhenAcceptLanguageStartsWithPt() throws Exception {
+    when(request.getRequestURI()).thenReturn("/events");
+    when(request.getHeader("Accept-Language")).thenReturn("pt-PT,pt;q=0.9");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(response).sendRedirect("/pt/events");
+    verify(filterChain, never()).doFilter(any(), any());
+  }
+
+  @Test
+  void shouldNotRedirectWhenPathHasEnglishLocale() throws Exception {
+    when(request.getRequestURI()).thenReturn("/en/events/1984");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(response, never()).sendRedirect(any());
+  }
+
+  @Test
+  void shouldNotRedirectWhenPathHasPortugueseLocale() throws Exception {
+    when(request.getRequestURI()).thenReturn("/pt/eventos/1984");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(response, never()).sendRedirect(any());
+  }
+
+  @Test
+  void shouldPassAppleTouchIconRequests() throws Exception {
+    when(request.getRequestURI()).thenReturn("/apple-touch-icon.png");
+
+    underTest.doFilter(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/OpenApiConfigTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/OpenApiConfigTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.junit.jupiter.api.Test;
+
+class OpenApiConfigTest {
+
+  @Test
+  void shouldCreateInstance() {
+    OpenApiConfig config = new OpenApiConfig();
+    assertNotNull(config);
+  }
+
+  @Test
+  void securitySchemesShouldBePresent() {
+    SecurityScheme[] schemes = OpenApiConfig.class.getAnnotationsByType(SecurityScheme.class);
+
+    assertNotNull(schemes);
+  }
+
+  @Test
+  void accountNameSchemeShouldBeApiKeyHeader() {
+    SecurityScheme accountName = OpenApiConfig.class.getAnnotationsByType(SecurityScheme.class)[0];
+
+    assertNotNull(accountName);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/OpenApiConfigTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/OpenApiConfigTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+ 
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.junit.jupiter.api.Test;
+
+class OpenApiConfigTest {
+
+  @Test
+  void shouldCreateInstance() {
+    OpenApiConfig config = new OpenApiConfig(new AppProperties());
+    assertNotNull(config);
+  }
+
+  @Test
+  void securitySchemesShouldBePresent() {
+    SecurityScheme[] schemes = OpenApiConfig.class.getAnnotationsByType(SecurityScheme.class);
+
+    assertNotNull(schemes);
+  }
+
+  @Test
+  void accountNameSchemeShouldBeApiKeyHeader() {
+    SecurityScheme accountName = OpenApiConfig.class.getAnnotationsByType(SecurityScheme.class)[0];
+
+    assertNotNull(accountName);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/PathVariableLocaleResolverTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/PathVariableLocaleResolverTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED AS IS AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PathVariableLocaleResolverTest {
+
+  private PathVariableLocaleResolver underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new PathVariableLocaleResolver();
+  }
+
+  @Test
+  void shouldResolveEnglishByDefault() {
+    HttpServletRequest request = createRequest("/events", null, null);
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.ENGLISH, result);
+  }
+
+  @Test
+  void shouldResolvePortugueseFromPath() {
+    HttpServletRequest request = createRequest("/pt/events", null, null);
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.of("pt", "PT"), result);
+  }
+
+  @Test
+  void shouldResolveEnglishFromPath() {
+    HttpServletRequest request = createRequest("/en/events/1984", null, null);
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.ENGLISH, result);
+  }
+
+  @Test
+  void shouldReturnEnglishForApiPaths() {
+    HttpServletRequest request = createRequest("/api/tracker/v1/devices", null, null);
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.ENGLISH, result);
+  }
+
+  @Test
+  void shouldResolvePortugueseFromAcceptLanguage() {
+    HttpServletRequest request = createRequest("/events", "pt-PT,pt;q=0.9,en;q=0.5", null);
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.of("pt", "PT"), result);
+  }
+
+  @Test
+  void shouldResolveEnglishFromAcceptLanguageWhenNotPortuguese() {
+    HttpServletRequest request = createRequest("/events", "fr-FR,fr;q=0.9", null);
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.ENGLISH, result);
+  }
+
+  @Test
+  void shouldResolveLocaleFromErrorRequestUri() {
+    HttpServletRequest request = createRequest("/error", null, "/pt/events/404");
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.of("pt", "PT"), result);
+  }
+
+  @Test
+  void shouldResolveEnglishFromErrorRequestUri() {
+    HttpServletRequest request = createRequest("/error", null, "/en/events/404");
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.ENGLISH, result);
+  }
+
+  @Test
+  void shouldStripContextPathFromErrorRequestUri() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn("/myapp/pt/events");
+    when(request.getContextPath()).thenReturn("/myapp");
+    when(request.getRequestURI()).thenReturn("/error");
+
+    Locale result = underTest.resolveLocale(request);
+
+    assertEquals(Locale.of("pt", "PT"), result);
+  }
+
+  @Test
+  void setLocaleShouldNotThrow() {
+    underTest.setLocale(mock(HttpServletRequest.class), null, Locale.ENGLISH);
+  }
+
+  private static HttpServletRequest createRequest(
+      String requestUri, String acceptLanguage, String errorRequestUri) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getRequestURI()).thenReturn(requestUri);
+    if (acceptLanguage != null) {
+      when(request.getHeader("Accept-Language")).thenReturn(acceptLanguage);
+    }
+    if (errorRequestUri != null) {
+      when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn(errorRequestUri);
+    }
+    return request;
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/WebConfigTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/WebConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.servlet.config.annotation.RedirectViewControllerRegistration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+
+@NullMarked
+class WebConfigTest {
+
+  @Test
+  void shouldCreateInstance() {
+    WebConfig config = new WebConfig();
+    assertNotNull(config);
+  }
+
+  @Test
+  void addViewControllersShouldRegisterRedirects() {
+    WebConfig config = new WebConfig();
+    TestViewControllerRegistry registry = new TestViewControllerRegistry();
+
+    config.addViewControllers(registry);
+
+    assertEquals(4, registry.redirectCount);
+  }
+
+  private static class TestViewControllerRegistry extends ViewControllerRegistry {
+
+    private int redirectCount = 0;
+
+    private TestViewControllerRegistry() {
+      super(mock(ApplicationContext.class));
+    }
+
+    @Override
+    public RedirectViewControllerRegistration addRedirectViewController(
+        String urlPath,
+        String redirectUri
+    ) {
+      redirectCount++;
+      return super.addRedirectViewController(urlPath, redirectUri);
+
+    }
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/config/WebConfigTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/config/WebConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.servlet.config.annotation.RedirectViewControllerRegistration;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+
+@NullMarked
+class WebConfigTest {
+
+  @Test
+  void shouldCreateInstance() {
+    WebConfig config = new WebConfig();
+    assertNotNull(config);
+  }
+
+  @Test
+  void addViewControllersShouldRegisterRedirects() {
+    WebConfig config = new WebConfig();
+    TestViewControllerRegistry registry = new TestViewControllerRegistry();
+
+    config.addViewControllers(registry);
+
+    assertEquals(2, registry.redirectCount);
+  }
+
+  private static class TestViewControllerRegistry extends ViewControllerRegistry {
+
+    private int redirectCount = 0;
+
+    private TestViewControllerRegistry() {
+      super(mock(ApplicationContext.class));
+    }
+
+    @Override
+    public RedirectViewControllerRegistration addRedirectViewController(
+        String urlPath,
+        String redirectUri
+    ) {
+      redirectCount++;
+      return super.addRedirectViewController(urlPath, redirectUri);
+
+    }
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/event/web/EventWebControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/event/web/EventWebControllerTest.java
@@ -61,6 +61,9 @@ class EventWebControllerTest {
   private static final YearsWithEventsDTO PAGE_1 = new YearsWithEventsDTO(List.of(1986, 1985, 1984),
       List.of(1983, 1982), List.of(1989, 1988, 1987), 1, 3, 8, 3, 0, 2
   );
+  private static final YearsWithEventsDTO PAGE_2 = new YearsWithEventsDTO(List.of(1983, 1982),
+      List.of(), List.of(1986, 1985, 1984), 2, 3, 8, 3, 0, -1
+  );
   private static final LocalDate EVENT_DATE = LocalDate.of(1984, Month.AUGUST, 15);
   private static final EventDTO EVENT_DTO = new EventDTO(1L, "Triatlo de Peniche", EVENT_DATE,
       EVENT_DATE, "Peniche", "Peniche", "Leiria", List.of("TRIATHLON")
@@ -178,6 +181,22 @@ class EventWebControllerTest {
         .andExpect(view().name("years-with-events"))
         .andExpect(model().attribute("language", "en"))
         .andExpect(model().attribute("yearsWithEvents", PAGE_1));
+  }
+
+  @Test
+  void eventYearsPageThirdPage() throws Exception {
+    when(messageService.getMessage(eq("page.events.metadata.title"), any(), any())).thenReturn(
+        "Events - EnduranceTrio");
+    when(
+        messageService.getMessage(eq("page.events.metadata.description"), any(), any())).thenReturn(
+        "Browse endurance sports events by year");
+    when(eventService.getEventYears()).thenReturn(ALL_YEARS);
+
+    mockMvc.perform(get("/en/events").param("page", "2"))
+        .andExpect(status().isOk())
+        .andExpect(view().name("years-with-events"))
+        .andExpect(model().attribute("language", "en"))
+        .andExpect(model().attribute("yearsWithEvents", PAGE_2));
   }
 
   @Test

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/newsletter/client/KitClientMainTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/newsletter/client/KitClientMainTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.newsletter.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.config.KitProperties;
+import com.endurancetrio.business.common.exception.EnduranceTrioException;
+import com.endurancetrio.business.newsletter.dto.NewsletterSubscriptionDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+class KitClientMainTest {
+
+  private static final String API_BASE_URL = "https://api.kit.com/v4";
+  private static final String API_VERSION = "v4";
+  private static final String API_KEY = "test-api-key";
+  private static final String API_KEY_HEADER = "X-Kit-Api-Key";
+  private static final String PATH_SUBSCRIBERS = "/subscribers";
+  private static final String PATH_FORM_SUBSCRIBERS = "/forms/{form_id}/subscribers/{subscriber_id}";
+  private static final Long SUBSCRIBER_ID = 123L;
+  private static final String FORM_ID = "form_abc";
+  private static final String FIRST_NAME = "John";
+  private static final String EMAIL = "john@example.com";
+
+  @Mock
+  private KitProperties kitProperties;
+
+  @Mock
+  private RestClient.Builder restClientBuilder;
+
+  @Mock
+  private RestClient restClient;
+
+  @Mock
+  private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+  @Mock
+  private RestClient.RequestBodySpec requestBodySpec;
+
+  @Mock
+  private RestClient.ResponseSpec responseSpec;
+
+  private KitClientMain underTest;
+
+  @BeforeEach
+  void setUp() {
+    when(kitProperties.getApiBaseUrl()).thenReturn(API_BASE_URL);
+    when(restClientBuilder.baseUrl(API_BASE_URL)).thenReturn(restClientBuilder);
+    when(restClientBuilder.build()).thenReturn(restClient);
+  }
+
+  @Test
+  void createOrUpdateSubscriberShouldReturnId() throws EnduranceTrioException {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathSubscribers()).thenReturn(PATH_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri("/" + API_VERSION + PATH_SUBSCRIBERS)).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
+      when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+      when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+      when(responseSpec.body((Class) any())).thenReturn(createMockResponse(SUBSCRIBER_ID));
+
+      Long result = underTest.createOrUpdateSubscriber(
+          new NewsletterSubscriptionDTO(FIRST_NAME, EMAIL));
+
+      assertEquals(SUBSCRIBER_ID, result);
+    }
+  }
+
+  @Test
+  void createOrUpdateSubscriberShouldThrowWhenResponseBodyIsNull() {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathSubscribers()).thenReturn(PATH_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri("/" + API_VERSION + PATH_SUBSCRIBERS)).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
+      when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+      when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+      when(responseSpec.body((Class) any())).thenReturn(null);
+
+      assertThrows(EnduranceTrioException.class,
+          () -> underTest.createOrUpdateSubscriber(
+              new NewsletterSubscriptionDTO(FIRST_NAME, EMAIL))
+      );
+    }
+  }
+
+  @Test
+  void createOrUpdateSubscriberShouldThrowOnRestClientException() {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathSubscribers()).thenReturn(PATH_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri("/" + API_VERSION + PATH_SUBSCRIBERS)).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
+      when(requestBodySpec.retrieve()).thenThrow(
+          new org.springframework.web.client.RestClientException("timeout"));
+
+      assertThrows(EnduranceTrioException.class,
+          () -> underTest.createOrUpdateSubscriber(
+              new NewsletterSubscriptionDTO(FIRST_NAME, EMAIL))
+      );
+    }
+  }
+
+  @Test
+  void createOrUpdateSubscriberShouldThrowOnHttpError() {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathSubscribers()).thenReturn(PATH_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri("/" + API_VERSION + PATH_SUBSCRIBERS)).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      doReturn(requestBodySpec).when(requestBodySpec).body(any(Object.class));
+      when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+      when(responseSpec.onStatus(any(), any())).thenAnswer(invocation -> {
+        RestClient.ResponseSpec.ErrorHandler handler = invocation.getArgument(1);
+        ClientHttpResponse errorResponse = mock(ClientHttpResponse.class);
+        when(errorResponse.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+        handler.handle(mock(HttpRequest.class), errorResponse);
+        return responseSpec;
+      });
+
+      assertThrows(EnduranceTrioException.class,
+          () -> underTest.createOrUpdateSubscriber(
+              new NewsletterSubscriptionDTO(FIRST_NAME, EMAIL))
+      );
+    }
+  }
+
+  @Test
+  void addSubscriberToFormShouldCompleteSuccessfully() throws EnduranceTrioException {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathFormSubscribers()).thenReturn(PATH_FORM_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri(eq("/" + API_VERSION + PATH_FORM_SUBSCRIBERS), eq(FORM_ID),
+          eq(SUBSCRIBER_ID)
+      )).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+      when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+      when(responseSpec.toBodilessEntity()).thenReturn(null);
+
+      underTest.addSubscriberToForm(SUBSCRIBER_ID, FORM_ID);
+    }
+  }
+
+  @Test
+  void addSubscriberToFormShouldThrowOnHttpError() {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathFormSubscribers()).thenReturn(PATH_FORM_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri(eq("/" + API_VERSION + PATH_FORM_SUBSCRIBERS), eq(FORM_ID),
+          eq(SUBSCRIBER_ID)
+      )).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+      when(responseSpec.onStatus(any(), any())).thenAnswer(invocation -> {
+        RestClient.ResponseSpec.ErrorHandler handler = invocation.getArgument(1);
+        ClientHttpResponse errorResponse = mock(ClientHttpResponse.class);
+        when(errorResponse.getStatusCode()).thenReturn(HttpStatus.BAD_REQUEST);
+        handler.handle(mock(HttpRequest.class), errorResponse);
+        return responseSpec;
+      });
+
+      assertThrows(EnduranceTrioException.class,
+          () -> underTest.addSubscriberToForm(SUBSCRIBER_ID, FORM_ID)
+      );
+    }
+  }
+
+  @Test
+  void addSubscriberToFormShouldThrowOnRestClientException() {
+    when(kitProperties.getApiVersion()).thenReturn(API_VERSION);
+    when(kitProperties.getApiKey()).thenReturn(API_KEY);
+    when(kitProperties.getApiKeyHeader()).thenReturn(API_KEY_HEADER);
+    when(kitProperties.getPathFormSubscribers()).thenReturn(PATH_FORM_SUBSCRIBERS);
+
+    try (MockedStatic<RestClient> restClientMock = mockStatic(RestClient.class)) {
+      restClientMock.when(RestClient::builder).thenReturn(restClientBuilder);
+      underTest = new KitClientMain(kitProperties);
+
+      when(restClient.post()).thenReturn(requestBodyUriSpec);
+      when(requestBodyUriSpec.uri(eq("/" + API_VERSION + PATH_FORM_SUBSCRIBERS), eq(FORM_ID),
+          eq(SUBSCRIBER_ID)
+      )).thenReturn(requestBodySpec);
+      when(requestBodySpec.header(API_KEY_HEADER, API_KEY)).thenReturn(requestBodySpec);
+      when(requestBodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(requestBodySpec);
+      when(requestBodySpec.retrieve()).thenThrow(
+          new org.springframework.web.client.RestClientException("connection refused"));
+
+      assertThrows(EnduranceTrioException.class,
+          () -> underTest.addSubscriberToForm(SUBSCRIBER_ID, FORM_ID)
+      );
+    }
+  }
+
+  private Object createMockResponse(Long subscriberId) {
+    try {
+      var subscriberClass = Class.forName(
+          "com.endurancetrio.app.newsletter.client.KitClientMain$KitSubscriber");
+      var responseClass = Class.forName(
+          "com.endurancetrio.app.newsletter.client.KitClientMain$KitSubscriberResponse");
+
+      var subscriberCon = subscriberClass.getDeclaredConstructor(Long.class);
+      subscriberCon.setAccessible(true);
+      Object subscriber = subscriberCon.newInstance(subscriberId);
+
+      var responseCon = responseClass.getDeclaredConstructor(subscriberClass);
+      responseCon.setAccessible(true);
+      return responseCon.newInstance(subscriber);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create mock response", e);
+    }
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/DeviceTelemetryRestControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/DeviceTelemetryRestControllerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.tracker.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import com.endurancetrio.business.common.exception.EnduranceTrioException;
+import com.endurancetrio.business.tracker.dto.DeviceTelemetryDTO;
+import com.endurancetrio.business.tracker.service.DeviceTelemetryService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceTelemetryRestControllerTest {
+
+  private static final String DEVICE = "SDABC";
+  private static final String OWNER = "testOwner";
+
+  @Mock
+  private DeviceTelemetryService deviceTelemetryService;
+
+  @InjectMocks
+  private DeviceTelemetryRestController underTest;
+
+  private DeviceTelemetryDTO testDTO;
+
+  @BeforeEach
+  void setUp() {
+    testDTO = new DeviceTelemetryDTO(DEVICE, null, null, null, false);
+  }
+
+  @Test
+  void getMostRecentRecordForEachDeviceShouldReturnList() {
+    List<DeviceTelemetryDTO> expectedData = List.of(testDTO);
+    when(deviceTelemetryService.findMostRecentRecordForEachDevice()).thenReturn(expectedData);
+
+    ResponseEntity<EnduranceTrioResponse<List<DeviceTelemetryDTO>>> response = underTest.getMostRecentRecordForEachDevice();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(200, response.getBody().status());
+    assertEquals(1, response.getBody().data().size());
+  }
+
+  @Test
+  void saveShouldReturnCreated() {
+    Authentication authentication = createMockAuthentication();
+
+    try (MockedStatic<SecurityContextHolder> securityContext = mockStatic(
+        SecurityContextHolder.class)) {
+      SecurityContext context = createMockSecurityContext(authentication);
+      securityContext.when(SecurityContextHolder::getContext).thenReturn(context);
+
+      when(deviceTelemetryService.save(OWNER, testDTO)).thenReturn(testDTO);
+
+      ResponseEntity<EnduranceTrioResponse<DeviceTelemetryDTO>> response = underTest.save(testDTO);
+
+      assertNotNull(response);
+      assertNotNull(response.getBody());
+      assertEquals(HttpStatus.CREATED, response.getStatusCode());
+      assertEquals(201, response.getBody().status());
+      assertEquals(DEVICE, response.getBody().data().device());
+    }
+  }
+
+  @Test
+  void saveWithNullBodyShouldThrowBadRequest() {
+    assertThrows(EnduranceTrioException.class, () -> underTest.save(null));
+  }
+
+  @Test
+  void saveWithUnauthenticatedShouldThrowUnauthorized() {
+    try (MockedStatic<SecurityContextHolder> securityContext = mockStatic(
+        SecurityContextHolder.class)) {
+      SecurityContext context = mockSecurityContextWithNullAuthentication();
+      securityContext.when(SecurityContextHolder::getContext).thenReturn(context);
+
+      assertThrows(EnduranceTrioException.class, () -> underTest.save(testDTO));
+    }
+  }
+
+  private static Authentication createMockAuthentication() {
+    Authentication authentication = org.mockito.Mockito.mock(Authentication.class);
+    when(authentication.getName()).thenReturn(OWNER);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    return authentication;
+  }
+
+  private static SecurityContext createMockSecurityContext(Authentication authentication) {
+    SecurityContext context = org.mockito.Mockito.mock(SecurityContext.class);
+    when(context.getAuthentication()).thenReturn(authentication);
+    return context;
+  }
+
+  private static SecurityContext mockSecurityContextWithNullAuthentication() {
+    SecurityContext context = org.mockito.Mockito.mock(SecurityContext.class);
+    when(context.getAuthentication()).thenReturn(null);
+    return context;
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/DeviceTelemetryRestControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/DeviceTelemetryRestControllerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.tracker.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import com.endurancetrio.business.common.exception.EnduranceTrioException;
+import com.endurancetrio.business.tracker.dto.DeviceTelemetryDTO;
+import com.endurancetrio.business.tracker.service.DeviceTelemetryService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceTelemetryRestControllerTest {
+
+  private static final String DEVICE = "SDABC";
+  private static final String OWNER = "testOwner";
+
+  @Mock
+  private DeviceTelemetryService deviceTelemetryService;
+
+  @InjectMocks
+  private DeviceTelemetryRestController underTest;
+
+  private DeviceTelemetryDTO testDTO;
+
+  @BeforeEach
+  void setUp() {
+    testDTO = new DeviceTelemetryDTO(DEVICE, null, null, null, false);
+  }
+
+  @Test
+  void getMostRecentRecordForEachDeviceShouldReturnList() {
+    List<DeviceTelemetryDTO> expectedData = List.of(testDTO);
+    when(deviceTelemetryService.findMostRecentRecordForEachDevice()).thenReturn(expectedData);
+
+    ResponseEntity<EnduranceTrioResponse<List<DeviceTelemetryDTO>>> response = underTest.getMostRecentRecordForEachDevice();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(200, response.getBody().status());
+    assertEquals(1, response.getBody().data().size());
+  }
+
+  @Test
+  void saveShouldReturnCreated() {
+    Authentication authentication = createMockAuthentication();
+
+    try (MockedStatic<SecurityContextHolder> securityContext = mockStatic(
+        SecurityContextHolder.class)) {
+      SecurityContext context = createMockSecurityContext(authentication);
+      securityContext.when(SecurityContextHolder::getContext).thenReturn(context);
+
+      when(deviceTelemetryService.save(OWNER, testDTO)).thenReturn(testDTO);
+
+      ResponseEntity<EnduranceTrioResponse<DeviceTelemetryDTO>> response = underTest.save(testDTO);
+
+      assertNotNull(response);
+      assertNotNull(response.getBody());
+      assertEquals(HttpStatus.CREATED, response.getStatusCode());
+      assertEquals(201, response.getBody().status());
+      assertEquals(DEVICE, response.getBody().data().device());
+    }
+  }
+
+  @Test
+  void saveWithNullBodyShouldThrowBadRequest() {
+    assertThrows(EnduranceTrioException.class, () -> underTest.save(null));
+  }
+
+  @Test
+  void saveWithUnauthenticatedShouldThrowUnauthorized() {
+    try (MockedStatic<SecurityContextHolder> securityContext = mockStatic(
+        SecurityContextHolder.class)) {
+      SecurityContext context = mockSecurityContextWithNullAuthentication();
+      securityContext.when(SecurityContextHolder::getContext).thenReturn(context);
+
+      assertThrows(EnduranceTrioException.class, () -> underTest.save(testDTO));
+    }
+  }
+
+  private static Authentication createMockAuthentication() {
+    Authentication authentication = org.mockito.Mockito.mock(Authentication.class);
+    when(authentication.getName()).thenReturn(OWNER);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    return authentication;
+  }
+
+  private static SecurityContext createMockSecurityContext(Authentication authentication) {
+    SecurityContext context = org.mockito.Mockito.mock(SecurityContext.class);
+    when(context.getAuthentication()).thenReturn(authentication);
+    return context;
+  }
+
+  private static SecurityContext mockSecurityContextWithNullAuthentication() {
+    SecurityContext context = org.mockito.Mockito.mock(SecurityContext.class);
+    when(context.getAuthentication()).thenReturn(null);
+    return context;
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/RouteRestControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/RouteRestControllerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.tracker.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import com.endurancetrio.business.tracker.dto.RouteDTO;
+import com.endurancetrio.business.tracker.dto.RouteMetricsDTO;
+import com.endurancetrio.business.tracker.dto.RouteSegmentDTO;
+import com.endurancetrio.business.tracker.service.RouteService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class RouteRestControllerTest {
+
+  private static final Long ROUTE_ID = 1L;
+  private static final String REFERENCE = "SMP";
+
+  @Mock
+  private RouteService routeService;
+
+  @InjectMocks
+  private RouteRestController underTest;
+
+  private RouteDTO testRoute;
+
+  @BeforeEach
+  void setUp() {
+    RouteSegmentDTO segment = new RouteSegmentDTO(1L, 1, "SDABC", "SDDEF");
+    testRoute = new RouteDTO(ROUTE_ID, REFERENCE, List.of(segment));
+  }
+
+  @Test
+  void findAllShouldReturnList() {
+    List<RouteDTO> expectedRoutes = List.of(testRoute);
+    when(routeService.findAll()).thenReturn(expectedRoutes);
+
+    ResponseEntity<EnduranceTrioResponse<List<RouteDTO>>> response = underTest.findAll();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(200, response.getBody().status());
+    assertEquals(1, response.getBody().data().size());
+  }
+
+  @Test
+  void createShouldReturnCreated() {
+    when(routeService.create(testRoute)).thenReturn(testRoute);
+
+    ResponseEntity<EnduranceTrioResponse<RouteDTO>> response = underTest.create(testRoute);
+
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(201, response.getBody().status());
+    assertEquals(REFERENCE, response.getBody().data().reference());
+  }
+
+  @Test
+  void updateShouldReturnOk() {
+    when(routeService.update(ROUTE_ID, testRoute)).thenReturn(testRoute);
+
+    ResponseEntity<EnduranceTrioResponse<RouteDTO>> response = underTest.update(ROUTE_ID,
+        testRoute
+    );
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getBody().status());
+    assertEquals(REFERENCE, response.getBody().data().reference());
+  }
+
+  @Test
+  void findByIdShouldReturnRoute() {
+    when(routeService.findById(ROUTE_ID)).thenReturn(testRoute);
+
+    ResponseEntity<EnduranceTrioResponse<RouteDTO>> response = underTest.findById(ROUTE_ID);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(ROUTE_ID, response.getBody().data().id());
+  }
+
+  @Test
+  void getRouteMetricsShouldReturnMetrics() {
+    RouteMetricsDTO metrics = new RouteMetricsDTO(List.of());
+    when(routeService.getRouteMetrics(ROUTE_ID)).thenReturn(metrics);
+
+    ResponseEntity<EnduranceTrioResponse<RouteMetricsDTO>> response = underTest.getRouteMetrics(
+        ROUTE_ID);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody().data());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/RouteRestControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/api/RouteRestControllerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.tracker.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import com.endurancetrio.app.common.response.EnduranceTrioResponse;
+import com.endurancetrio.business.tracker.dto.RouteDTO;
+import com.endurancetrio.business.tracker.dto.RouteMetricsDTO;
+import com.endurancetrio.business.tracker.dto.RouteSegmentDTO;
+import com.endurancetrio.business.tracker.service.RouteService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class RouteRestControllerTest {
+
+  private static final Long ROUTE_ID = 1L;
+  private static final String REFERENCE = "SMP";
+
+  @Mock
+  private RouteService routeService;
+
+  @InjectMocks
+  private RouteRestController underTest;
+
+  private RouteDTO testRoute;
+
+  @BeforeEach
+  void setUp() {
+    RouteSegmentDTO segment = new RouteSegmentDTO(1L, 1, "SDABC", "SDDEF");
+    testRoute = new RouteDTO(ROUTE_ID, REFERENCE, List.of(segment));
+  }
+
+  @Test
+  void findAllShouldReturnList() {
+    List<RouteDTO> expectedRoutes = List.of(testRoute);
+    when(routeService.findAll()).thenReturn(expectedRoutes);
+
+    ResponseEntity<EnduranceTrioResponse<List<RouteDTO>>> response = underTest.findAll();
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(200, response.getBody().status());
+    assertEquals(1, response.getBody().data().size());
+  }
+
+  @Test
+  void createShouldReturnCreated() {
+    when(routeService.create(testRoute)).thenReturn(testRoute);
+
+    ResponseEntity<EnduranceTrioResponse<RouteDTO>> response = underTest.create(testRoute);
+
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    assertNotNull(response.getBody());
+    assertEquals(201, response.getBody().status());
+    assertEquals(REFERENCE, response.getBody().data().reference());
+  }
+
+  @Test
+  void updateShouldReturnOk() {
+    when(routeService.update(ROUTE_ID, testRoute)).thenReturn(testRoute);
+
+    ResponseEntity<EnduranceTrioResponse<RouteDTO>> response = underTest.update(ROUTE_ID,
+        testRoute
+    );
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(200, response.getBody().status());
+    assertEquals(REFERENCE, response.getBody().data().reference());
+  }
+
+  @Test
+  void findByIdShouldReturnRoute() {
+    when(routeService.findById(ROUTE_ID)).thenReturn(testRoute);
+
+    ResponseEntity<EnduranceTrioResponse<RouteDTO>> response = underTest.findById(ROUTE_ID);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(ROUTE_ID, response.getBody().data().id());
+  }
+
+  @Test
+  void getRouteMetricsShouldReturnMetrics() {
+    RouteMetricsDTO metrics = new RouteMetricsDTO(List.of());
+    when(routeService.getRouteMetrics(ROUTE_ID)).thenReturn(metrics);
+
+    ResponseEntity<EnduranceTrioResponse<RouteMetricsDTO>> response = underTest.getRouteMetrics(
+        ROUTE_ID);
+
+    assertNotNull(response.getBody());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNotNull(response.getBody().data());
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/constants/TrackerPathsAPITest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/constants/TrackerPathsAPITest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.tracker.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class TrackerPathsAPITest {
+
+  @Test
+  void trackerV1ShouldBeV1() {
+    assertEquals("/v1", TrackerPathsAPI.TRACKER_V1);
+  }
+
+  @Test
+  void trackerDomainShouldBeTracker() {
+    assertEquals("/tracker", TrackerPathsAPI.TRACKER_DOMAIN);
+  }
+
+  @Test
+  void trackerResourceDevicesShouldBeDevices() {
+    assertEquals("/devices", TrackerPathsAPI.TRACKER_RESOURCE_DEVICES);
+  }
+
+  @Test
+  void trackerResourceRoutesShouldBeRoutes() {
+    assertEquals("/routes", TrackerPathsAPI.TRACKER_RESOURCE_ROUTES);
+  }
+
+  @Test
+  void constructorShouldThrow() {
+    assertThrows(IllegalStateException.class, TrackerPathsAPI::new);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/constants/TrackerPathsAPITest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/tracker/constants/TrackerPathsAPITest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.tracker.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class TrackerPathsAPITest {
+
+  @Test
+  void trackerV1ShouldBeV1() {
+    assertEquals("/v1", TrackerPathsAPI.TRACKER_V1);
+  }
+
+  @Test
+  void trackerDomainShouldBeTracker() {
+    assertEquals("/tracker", TrackerPathsAPI.TRACKER_DOMAIN);
+  }
+
+  @Test
+  void trackerResourceDevicesShouldBeDevices() {
+    assertEquals("/devices", TrackerPathsAPI.TRACKER_RESOURCE_DEVICES);
+  }
+
+  @Test
+  void trackerResourceRoutesShouldBeRoutes() {
+    assertEquals("/routes", TrackerPathsAPI.TRACKER_RESOURCE_ROUTES);
+  }
+
+  @Test
+  void constructorShouldThrow() {
+    assertThrows(IllegalStateException.class, TrackerPathsAPI::new);
+  }
+}

--- a/endurancetrio-business/pom.xml
+++ b/endurancetrio-business/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.endurancetrio</groupId>
     <artifactId>endurancetrio-tracker</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/Feature.java
+++ b/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/Feature.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * @param type       the type of the GeoJSON object, always "Feature"
  * @param geometry   the geometry of the feature
  * @param properties a map of properties associated with the feature
- * @see <a href="https://geojson.org/" />
+ * @see <a href="https://geojson.org/">geojson.org</a>
  */
 public record Feature(
     String type, Geometry geometry, Map<String, Object> properties) {

--- a/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/Geometry.java
+++ b/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/Geometry.java
@@ -22,7 +22,7 @@ package com.endurancetrio.business.tracker.dto.geojson;
 
 /**
  * Represents a GeoJSON geometry
- * @see <a href="https://geojson.org/" />
+ * @see <a href="https://geojson.org/">geojson.org</a>
  */
 public sealed interface Geometry permits PointGeometry, LineStringGeometry {
 

--- a/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/LineStringGeometry.java
+++ b/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/LineStringGeometry.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Represents a GeoJSON LineString geometry.
  *
  * @param coordinates the coordinates of the LineString as a list of doubles lists
- * @see <a href="https://geojson.org/" />
+ * @see <a href="https://geojson.org/">geojson.org</a>
  */
 public record LineStringGeometry(
     @JsonProperty("coordinates") List<List<Double>> coordinates) implements Geometry {

--- a/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/PointGeometry.java
+++ b/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/dto/geojson/PointGeometry.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Represents a GeoJSON Point geometry.
  *
  * @param coordinates the coordinates of the point as a list of doubles
- * @see <a href="https://geojson.org/" />
+ * @see <a href="https://geojson.org/">geojson.org</a>
  */
 public record PointGeometry(
     @JsonProperty("coordinates") List<Double> coordinates) implements Geometry {

--- a/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/validator/RouteSegmentsValidator.java
+++ b/endurancetrio-business/src/main/java/com/endurancetrio/business/tracker/validator/RouteSegmentsValidator.java
@@ -36,7 +36,6 @@ import java.util.List;
  * <li><b>Continuity:</b> The {@code endDevice} of segment N must match the {@code startDevice} of segment N+1.</li>
  * <li><b>Sequence:</b> Segment orders must be strictly sequential (1, 2, 3...) without gaps.</li>
  * </ol>
- * </p>
  */
 public class RouteSegmentsValidator implements ConstraintValidator<RouteSegmentsValid, RouteDTO> {
 

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/common/dto/ErrorDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/common/dto/ErrorDTOTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.common.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link ErrorDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class ErrorDTOTest {
+
+  private static final int CODE = 404;
+  private static final String ERROR = "NOT_FOUND";
+  private static final String MESSAGE = "The requested resource was not found";
+
+  private ErrorDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new ErrorDTO(CODE, ERROR, MESSAGE);
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(CODE, underTest.code());
+    assertEquals(ERROR, underTest.error());
+    assertEquals(MESSAGE, underTest.message());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/common/dto/ErrorDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/common/dto/ErrorDTOTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.common.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link ErrorDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class ErrorDTOTest {
+
+  private static final int CODE = 404;
+  private static final String ERROR = "NOT_FOUND";
+  private static final String MESSAGE = "The requested resource was not found";
+
+  private ErrorDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new ErrorDTO(CODE, ERROR, MESSAGE);
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(CODE, underTest.code());
+    assertEquals(ERROR, underTest.error());
+    assertEquals(MESSAGE, underTest.message());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioErrorTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioErrorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.common.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class EnduranceTrioErrorTest {
+
+  @Test
+  void badRequestShouldHaveCode400() {
+    assertEquals(400, EnduranceTrioError.BAD_REQUEST.getCode());
+  }
+
+  @Test
+  void unauthorizedShouldHaveCode401() {
+    assertEquals(401, EnduranceTrioError.UNAUTHORIZED.getCode());
+  }
+
+  @Test
+  void notFoundShouldHaveCode404() {
+    assertEquals(404, EnduranceTrioError.NOT_FOUND.getCode());
+  }
+
+  @Test
+  void conflictShouldHaveCode409() {
+    assertEquals(409, EnduranceTrioError.CONFLICT.getCode());
+  }
+
+  @Test
+  void internalErrorShouldHaveCode500() {
+    assertEquals(500, EnduranceTrioError.INTERNAL_ERROR.getCode());
+  }
+
+  @Test
+  void fromCodeShouldReturnMatchingError() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(404);
+
+    assertTrue(result.isPresent());
+    assertEquals(EnduranceTrioError.NOT_FOUND, result.get());
+  }
+
+  @Test
+  void fromCodeShouldReturnEmptyForUnknownCode() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(999);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void fromCodeShouldFindBadRequest() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(400);
+
+    assertTrue(result.isPresent());
+    assertEquals(EnduranceTrioError.BAD_REQUEST, result.get());
+  }
+
+  @Test
+  void fromCodeShouldFindInternalError() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(500);
+
+    assertTrue(result.isPresent());
+    assertEquals(EnduranceTrioError.INTERNAL_ERROR, result.get());
+  }
+
+  @Test
+  void badRequestShouldHaveMessage() {
+    assertEquals("The request was made with invalid or incomplete data",
+        EnduranceTrioError.BAD_REQUEST.getMessage()
+    );
+  }
+
+  @Test
+  void unauthorizedShouldHaveMessage() {
+    assertEquals("Authentication is required to access this resource",
+        EnduranceTrioError.UNAUTHORIZED.getMessage()
+    );
+  }
+
+  @Test
+  void notFoundShouldHaveMessage() {
+    assertEquals("The requested resource was not found", EnduranceTrioError.NOT_FOUND.getMessage());
+  }
+
+  @Test
+  void conflictShouldHaveMessage() {
+    assertEquals("A conflict occurred with the current state of the resource",
+        EnduranceTrioError.CONFLICT.getMessage()
+    );
+  }
+
+  @Test
+  void internalErrorShouldHaveMessage() {
+    assertEquals("An internal server error occurred",
+        EnduranceTrioError.INTERNAL_ERROR.getMessage()
+    );
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioErrorTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioErrorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.common.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class EnduranceTrioErrorTest {
+
+  @Test
+  void badRequestShouldHaveCode400() {
+    assertEquals(400, EnduranceTrioError.BAD_REQUEST.getCode());
+  }
+
+  @Test
+  void unauthorizedShouldHaveCode401() {
+    assertEquals(401, EnduranceTrioError.UNAUTHORIZED.getCode());
+  }
+
+  @Test
+  void notFoundShouldHaveCode404() {
+    assertEquals(404, EnduranceTrioError.NOT_FOUND.getCode());
+  }
+
+  @Test
+  void conflictShouldHaveCode409() {
+    assertEquals(409, EnduranceTrioError.CONFLICT.getCode());
+  }
+
+  @Test
+  void internalErrorShouldHaveCode500() {
+    assertEquals(500, EnduranceTrioError.INTERNAL_ERROR.getCode());
+  }
+
+  @Test
+  void fromCodeShouldReturnMatchingError() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(404);
+
+    assertTrue(result.isPresent());
+    assertEquals(EnduranceTrioError.NOT_FOUND, result.get());
+  }
+
+  @Test
+  void fromCodeShouldReturnEmptyForUnknownCode() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(999);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void fromCodeShouldFindBadRequest() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(400);
+
+    assertTrue(result.isPresent());
+    assertEquals(EnduranceTrioError.BAD_REQUEST, result.get());
+  }
+
+  @Test
+  void fromCodeShouldFindInternalError() {
+    Optional<EnduranceTrioError> result = EnduranceTrioError.fromCode(500);
+
+    assertTrue(result.isPresent());
+    assertEquals(EnduranceTrioError.INTERNAL_ERROR, result.get());
+  }
+
+  @Test
+  void badRequestShouldHaveMessage() {
+    assertEquals("The request was made with invalid or incomplete data",
+        EnduranceTrioError.BAD_REQUEST.getMessage()
+    );
+  }
+
+  @Test
+  void unauthorizedShouldHaveMessage() {
+    assertEquals("Authentication is required to access this resource",
+        EnduranceTrioError.UNAUTHORIZED.getMessage()
+    );
+  }
+
+  @Test
+  void notFoundShouldHaveMessage() {
+    assertEquals("The requested resource was not found", EnduranceTrioError.NOT_FOUND.getMessage());
+  }
+
+  @Test
+  void conflictShouldHaveMessage() {
+    assertEquals("A conflict occurred with the current state of the resource",
+        EnduranceTrioError.CONFLICT.getMessage()
+    );
+  }
+
+  @Test
+  void internalErrorShouldHaveMessage() {
+    assertEquals("An internal server error occurred",
+        EnduranceTrioError.INTERNAL_ERROR.getMessage()
+    );
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioExceptionTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioExceptionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.common.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.endurancetrio.business.common.dto.ErrorDTO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EnduranceTrioExceptionTest {
+
+  @Test
+  void shouldCreateWithSingleError() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.NOT_FOUND);
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    assertEquals(404, exception.getCode());
+    assertEquals(1, exception.getErrors().size());
+    assertEquals("NOT_FOUND", exception.getErrors().getFirst().error());
+    assertNotNull(exception.getMessage());
+  }
+
+  @Test
+  void shouldCreateWithMultipleErrors() {
+    ErrorDTO error1 = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "field1 is required");
+    ErrorDTO error2 = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "field2 is invalid");
+    List<ErrorDTO> errors = List.of(error1, error2);
+
+    EnduranceTrioException exception = new EnduranceTrioException(errors);
+
+    assertEquals(400, exception.getCode());
+    assertEquals(2, exception.getErrors().size());
+  }
+
+  @Test
+  void shouldRetainFirstErrorCode() {
+    ErrorDTO error1 = new ErrorDTO(EnduranceTrioError.NOT_FOUND);
+    ErrorDTO error2 = new ErrorDTO(EnduranceTrioError.BAD_REQUEST);
+
+    EnduranceTrioException exception = new EnduranceTrioException(List.of(error1, error2));
+
+    assertEquals(404, exception.getCode());
+  }
+
+  @Test
+  void shouldHandleInternalError() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.INTERNAL_ERROR);
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    assertEquals(500, exception.getCode());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioExceptionTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/common/exception/EnduranceTrioExceptionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.common.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.endurancetrio.business.common.dto.ErrorDTO;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EnduranceTrioExceptionTest {
+
+  @Test
+  void shouldCreateWithSingleError() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.NOT_FOUND);
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    assertEquals(404, exception.getCode());
+    assertEquals(1, exception.getErrors().size());
+    assertEquals("NOT_FOUND", exception.getErrors().getFirst().error());
+    assertNotNull(exception.getMessage());
+  }
+
+  @Test
+  void shouldCreateWithMultipleErrors() {
+    ErrorDTO error1 = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "field1 is required");
+    ErrorDTO error2 = new ErrorDTO(EnduranceTrioError.BAD_REQUEST, "field2 is invalid");
+    List<ErrorDTO> errors = List.of(error1, error2);
+
+    EnduranceTrioException exception = new EnduranceTrioException(errors);
+
+    assertEquals(400, exception.getCode());
+    assertEquals(2, exception.getErrors().size());
+  }
+
+  @Test
+  void shouldRetainFirstErrorCode() {
+    ErrorDTO error1 = new ErrorDTO(EnduranceTrioError.NOT_FOUND);
+    ErrorDTO error2 = new ErrorDTO(EnduranceTrioError.BAD_REQUEST);
+
+    EnduranceTrioException exception = new EnduranceTrioException(List.of(error1, error2));
+
+    assertEquals(404, exception.getCode());
+  }
+
+  @Test
+  void shouldHandleInternalError() {
+    ErrorDTO error = new ErrorDTO(EnduranceTrioError.INTERNAL_ERROR);
+    EnduranceTrioException exception = new EnduranceTrioException(error);
+
+    assertEquals(500, exception.getCode());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/event/mapper/EventFileMapperTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/event/mapper/EventFileMapperTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THE POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.event.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.endurancetrio.business.event.dto.EventFileDTO;
+import com.endurancetrio.data.event.model.entity.EventFile;
+import com.endurancetrio.data.event.model.enumerator.FileType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class   EventFileMapperTest {
+
+  private static final Long ID = 1L;
+  private static final String TITLE = "Regulamento";
+  private static final FileType FILE_TYPE = FileType.RULES;
+  private static final String FILE_NAME = "19840815NAC001-REG001-01.pdf";
+
+  private EventFile entityTest;
+
+  private EventFileMapper underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new EventFileMapper();
+
+    entityTest = new EventFile();
+    entityTest.setId(ID);
+    entityTest.setTitle(TITLE);
+    entityTest.setFileType(FILE_TYPE);
+    entityTest.setFileName(FILE_NAME);
+  }
+
+  @Test
+  void mapEntity() {
+    EventFileDTO result = underTest.map(entityTest);
+
+    assertNotNull(result);
+    assertEquals(ID, result.id());
+    assertEquals(TITLE, result.title());
+    assertEquals(FILE_TYPE.getCode(), result.fileType());
+    assertEquals(FILE_NAME, result.fileName());
+  }
+
+  @Test
+  void mapNullEntity() {
+    EventFileDTO result = underTest.map((EventFile) null);
+
+    assertNull(result);
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/annotation/RouteSegmentsValidTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/annotation/RouteSegmentsValidTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteSegmentsValid} annotation.
+ * <p>
+ * This test may seem redundant since it only verifies annotation properties, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteSegmentsValidTest {
+
+  @Test
+  void shouldBeTargetedAtType() {
+    Target target = RouteSegmentsValid.class.getAnnotation(Target.class);
+
+    assertNotNull(target);
+    assertEquals(1, target.value().length);
+    assertEquals(ElementType.TYPE, target.value()[0]);
+  }
+
+  @Test
+  void shouldHaveRuntimeRetention() {
+    Retention retention = RouteSegmentsValid.class.getAnnotation(Retention.class);
+
+    assertNotNull(retention);
+    assertEquals(RetentionPolicy.RUNTIME, retention.value());
+  }
+
+  @Test
+  void shouldBeConstraint() {
+    Constraint constraint = RouteSegmentsValid.class.getAnnotation(Constraint.class);
+
+    assertNotNull(constraint);
+    assertNotNull(constraint.validatedBy());
+  }
+
+  @Test
+  void shouldHaveDefaultMessage() {
+    RouteSegmentsValid annotation = AnnotatedClass.class.getAnnotation(RouteSegmentsValid.class);
+
+    assertNotNull(annotation);
+    assertTrue(annotation.message().contains("continuous sequence"));
+  }
+
+  @RouteSegmentsValid
+  private static class AnnotatedClass {
+
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/annotation/RouteSegmentsValidTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/annotation/RouteSegmentsValidTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteSegmentsValid} annotation.
+ * <p>
+ * This test may seem redundant since it only verifies annotation properties, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteSegmentsValidTest {
+
+  @Test
+  void shouldBeTargetedAtType() {
+    Target target = RouteSegmentsValid.class.getAnnotation(Target.class);
+
+    assertNotNull(target);
+    assertEquals(1, target.value().length);
+    assertEquals(ElementType.TYPE, target.value()[0]);
+  }
+
+  @Test
+  void shouldHaveRuntimeRetention() {
+    Retention retention = RouteSegmentsValid.class.getAnnotation(Retention.class);
+
+    assertNotNull(retention);
+    assertEquals(RetentionPolicy.RUNTIME, retention.value());
+  }
+
+  @Test
+  void shouldBeConstraint() {
+    Constraint constraint = RouteSegmentsValid.class.getAnnotation(Constraint.class);
+
+    assertNotNull(constraint);
+    assertNotNull(constraint.validatedBy());
+  }
+
+  @Test
+  void shouldHaveDefaultMessage() {
+    RouteSegmentsValid annotation = AnnotatedClass.class.getAnnotation(RouteSegmentsValid.class);
+
+    assertNotNull(annotation);
+    assertTrue(annotation.message().contains("continuous sequence"));
+  }
+
+  @RouteSegmentsValid
+  private static class AnnotatedClass {
+
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteDTOTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteDTOTest {
+
+  private static final Long ID = 1L;
+  private static final String REFERENCE = "SMP";
+  private static final RouteSegmentDTO SEGMENT = new RouteSegmentDTO(1L, 1, "SDABC", "SDDEF");
+
+  private RouteDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RouteDTO(ID, REFERENCE, List.of(SEGMENT));
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(ID, underTest.id());
+    assertEquals(REFERENCE, underTest.reference());
+    assertEquals(1, underTest.segments().size());
+    assertEquals("SDABC", underTest.segments().getFirst().startDevice());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteDTOTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteDTOTest {
+
+  private static final Long ID = 1L;
+  private static final String REFERENCE = "SMP";
+  private static final RouteSegmentDTO SEGMENT = new RouteSegmentDTO(1L, 1, "SDABC", "SDDEF");
+
+  private RouteDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RouteDTO(ID, REFERENCE, List.of(SEGMENT));
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(ID, underTest.id());
+    assertEquals(REFERENCE, underTest.reference());
+    assertEquals(1, underTest.segments().size());
+    assertEquals("SDABC", underTest.segments().getFirst().startDevice());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteMetricsDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteMetricsDTOTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.endurancetrio.business.tracker.dto.geojson.Feature;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteMetricsDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteMetricsDTOTest {
+
+  private static final String TYPE = "FeatureCollection";
+  private static final Feature FEATURE = Feature.of(null, null);
+
+  private RouteMetricsDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RouteMetricsDTO(TYPE, List.of(FEATURE));
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(TYPE, underTest.type());
+    assertEquals(1, underTest.features().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteMetricsDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteMetricsDTOTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.endurancetrio.business.tracker.dto.geojson.Feature;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteMetricsDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteMetricsDTOTest {
+
+  private static final String TYPE = "FeatureCollection";
+  private static final Feature FEATURE = Feature.of(null, null);
+
+  private RouteMetricsDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RouteMetricsDTO(TYPE, List.of(FEATURE));
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(TYPE, underTest.type());
+    assertEquals(1, underTest.features().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteSegmentDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteSegmentDTOTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteSegmentDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteSegmentDTOTest {
+
+  private static final Long ID = 1L;
+  private static final Integer ORDER = 1;
+  private static final String START_DEVICE = "SDABC";
+  private static final String END_DEVICE = "SDDEF";
+
+  private RouteSegmentDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RouteSegmentDTO(ID, ORDER, START_DEVICE, END_DEVICE);
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(ID, underTest.id());
+    assertEquals(ORDER, underTest.order());
+    assertEquals(START_DEVICE, underTest.startDevice());
+    assertEquals(END_DEVICE, underTest.endDevice());
+    assertTrue(underTest.areDevicesDifferent());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteSegmentDTOTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/RouteSegmentDTOTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RouteSegmentDTO} DTO.
+ * <p>
+ * This test may seem redundant since it only verify getters and setters, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class RouteSegmentDTOTest {
+
+  private static final Long ID = 1L;
+  private static final Integer ORDER = 1;
+  private static final String START_DEVICE = "SDABC";
+  private static final String END_DEVICE = "SDDEF";
+
+  private RouteSegmentDTO underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RouteSegmentDTO(ID, ORDER, START_DEVICE, END_DEVICE);
+  }
+
+  @Test
+  void dtoShouldRetainValues() {
+
+    assertEquals(ID, underTest.id());
+    assertEquals(ORDER, underTest.order());
+    assertEquals(START_DEVICE, underTest.startDevice());
+    assertEquals(END_DEVICE, underTest.endDevice());
+    assertTrue(underTest.areDevicesDifferent());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/FeatureTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/FeatureTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FeatureTest {
+
+  @Test
+  void shouldCreateWithTypeGeometryAndProperties() {
+    Geometry geometry = new PointGeometry(List.of(1.0, 2.0));
+    Map<String, Object> properties = Map.of("key", "value");
+    Feature feature = new Feature("Feature", geometry, properties);
+
+    assertEquals("Feature", feature.type());
+    assertEquals(geometry, feature.geometry());
+    assertEquals(properties, feature.properties());
+  }
+
+  @Test
+  void ofShouldCreateFeatureWithType() {
+    Geometry geometry = new PointGeometry(List.of(1.0, 2.0));
+    Feature feature = Feature.of(geometry, null);
+
+    assertEquals("Feature", feature.type());
+    assertEquals(geometry, feature.geometry());
+    assertNull(feature.properties());
+  }
+
+  @Test
+  void ofShouldCreateFeatureWithNullGeometry() {
+    Feature feature = Feature.of(null, null);
+
+    assertEquals("Feature", feature.type());
+    assertNull(feature.geometry());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/FeatureTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/FeatureTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FeatureTest {
+
+  @Test
+  void shouldCreateWithTypeGeometryAndProperties() {
+    Geometry geometry = new PointGeometry(List.of(1.0, 2.0));
+    Map<String, Object> properties = Map.of("key", "value");
+    Feature feature = new Feature("Feature", geometry, properties);
+
+    assertEquals("Feature", feature.type());
+    assertEquals(geometry, feature.geometry());
+    assertEquals(properties, feature.properties());
+  }
+
+  @Test
+  void ofShouldCreateFeatureWithType() {
+    Geometry geometry = new PointGeometry(List.of(1.0, 2.0));
+    Feature feature = Feature.of(geometry, null);
+
+    assertEquals("Feature", feature.type());
+    assertEquals(geometry, feature.geometry());
+    assertNull(feature.properties());
+  }
+
+  @Test
+  void ofShouldCreateFeatureWithNullGeometry() {
+    Feature feature = Feature.of(null, null);
+
+    assertEquals("Feature", feature.type());
+    assertNull(feature.geometry());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/LineStringGeometryTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/LineStringGeometryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LineStringGeometryTest {
+
+  @Test
+  void shouldReturnLineStringType() {
+    LineStringGeometry geometry = new LineStringGeometry(List.of());
+
+    assertEquals("LineString", geometry.getType());
+  }
+
+  @Test
+  void shouldRetainCoordinates() {
+    List<List<Double>> coordinates = List.of(
+        List.of(1.0, 2.0),
+        List.of(3.0, 4.0)
+    );
+    LineStringGeometry geometry = new LineStringGeometry(coordinates);
+
+    assertEquals(coordinates, geometry.coordinates());
+    assertEquals(2, geometry.coordinates().size());
+  }
+
+  @Test
+  void shouldHandleEmptyCoordinates() {
+    LineStringGeometry geometry = new LineStringGeometry(List.of());
+
+    assertEquals(0, geometry.coordinates().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/LineStringGeometryTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/LineStringGeometryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LineStringGeometryTest {
+
+  @Test
+  void shouldReturnLineStringType() {
+    LineStringGeometry geometry = new LineStringGeometry(List.of());
+
+    assertEquals("LineString", geometry.getType());
+  }
+
+  @Test
+  void shouldRetainCoordinates() {
+    List<List<Double>> coordinates = List.of(
+        List.of(1.0, 2.0),
+        List.of(3.0, 4.0)
+    );
+    LineStringGeometry geometry = new LineStringGeometry(coordinates);
+
+    assertEquals(coordinates, geometry.coordinates());
+    assertEquals(2, geometry.coordinates().size());
+  }
+
+  @Test
+  void shouldHandleEmptyCoordinates() {
+    LineStringGeometry geometry = new LineStringGeometry(List.of());
+
+    assertEquals(0, geometry.coordinates().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/PointGeometryTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/PointGeometryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PointGeometryTest {
+
+  @Test
+  void shouldReturnPointType() {
+    PointGeometry geometry = new PointGeometry(List.of(1.0, 2.0));
+
+    assertEquals("Point", geometry.getType());
+  }
+
+  @Test
+  void shouldRetainCoordinates() {
+    List<Double> coordinates = List.of(1.0, 2.0, 3.0);
+    PointGeometry geometry = new PointGeometry(coordinates);
+
+    assertEquals(coordinates, geometry.coordinates());
+    assertEquals(3, geometry.coordinates().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/PointGeometryTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/PointGeometryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PointGeometryTest {
+
+  @Test
+  void shouldReturnPointType() {
+    PointGeometry geometry = new PointGeometry(List.of(1.0, 2.0));
+
+    assertEquals("Point", geometry.getType());
+  }
+
+  @Test
+  void shouldRetainCoordinates() {
+    List<Double> coordinates = List.of(1.0, 2.0, 3.0);
+    PointGeometry geometry = new PointGeometry(coordinates);
+
+    assertEquals(coordinates, geometry.coordinates());
+    assertEquals(3, geometry.coordinates().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RoutePropertyTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RoutePropertyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RoutePropertyTest {
+
+  private static final Long ID = 1L;
+  private static final String REFERENCE = "SMP";
+  private static final Long TOTAL_DISTANCE = 1000L;
+
+  @Test
+  void shouldCreateWithAllFields() {
+    RouteSegmentProperty segment = new RouteSegmentProperty(1, 500L);
+    RouteProperty property = new RouteProperty(ID, REFERENCE, TOTAL_DISTANCE, List.of(segment));
+
+    assertEquals(ID, property.id());
+    assertEquals(REFERENCE, property.reference());
+    assertEquals(TOTAL_DISTANCE, property.totalDistance());
+    assertEquals(1, property.segments().size());
+  }
+
+  @Test
+  void shouldHandleEmptySegments() {
+    RouteProperty property = new RouteProperty(ID, REFERENCE, TOTAL_DISTANCE, List.of());
+
+    assertEquals(0, property.segments().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RoutePropertyTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RoutePropertyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RoutePropertyTest {
+
+  private static final Long ID = 1L;
+  private static final String REFERENCE = "SMP";
+  private static final Long TOTAL_DISTANCE = 1000L;
+
+  @Test
+  void shouldCreateWithAllFields() {
+    RouteSegmentProperty segment = new RouteSegmentProperty(1, 500L);
+    RouteProperty property = new RouteProperty(ID, REFERENCE, TOTAL_DISTANCE, List.of(segment));
+
+    assertEquals(ID, property.id());
+    assertEquals(REFERENCE, property.reference());
+    assertEquals(TOTAL_DISTANCE, property.totalDistance());
+    assertEquals(1, property.segments().size());
+  }
+
+  @Test
+  void shouldHandleEmptySegments() {
+    RouteProperty property = new RouteProperty(ID, REFERENCE, TOTAL_DISTANCE, List.of());
+
+    assertEquals(0, property.segments().size());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RouteSegmentPropertyTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RouteSegmentPropertyTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class RouteSegmentPropertyTest {
+
+  private static final Integer ORDER = 1;
+  private static final Long SEGMENT_DISTANCE = 500L;
+
+  @Test
+  void shouldCreateWithOrderAndDistance() {
+    RouteSegmentProperty property = new RouteSegmentProperty(ORDER, SEGMENT_DISTANCE);
+
+    assertEquals(ORDER, property.order());
+    assertEquals(SEGMENT_DISTANCE, property.segmentDistance());
+  }
+}

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RouteSegmentPropertyTest.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/tracker/dto/geojson/RouteSegmentPropertyTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.business.tracker.dto.geojson;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class RouteSegmentPropertyTest {
+
+  private static final Integer ORDER = 1;
+  private static final Long SEGMENT_DISTANCE = 500L;
+
+  @Test
+  void shouldCreateWithOrderAndDistance() {
+    RouteSegmentProperty property = new RouteSegmentProperty(ORDER, SEGMENT_DISTANCE);
+
+    assertEquals(ORDER, property.order());
+    assertEquals(SEGMENT_DISTANCE, property.segmentDistance());
+  }
+}

--- a/endurancetrio-data/pom.xml
+++ b/endurancetrio-data/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>com.endurancetrio</groupId>
     <artifactId>endurancetrio-tracker</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/common/model/entity/AuditableEntity.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/common/model/entity/AuditableEntity.java
@@ -45,9 +45,7 @@ public abstract class AuditableEntity implements Serializable {
    * When an entity is updated, the version number is incremented. If another transaction has
    * modified the entity in the meantime, a {@code OptimisticLockException} is thrown.
    * <p>
-   * See <a
-   * href="https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#locking-optimistic"
-   * />
+   * See <a href="https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#locking-optimistic">Hibernate ORM – Optimistic Locking</a>
    */
   @Version
   @Column(name = "version", nullable = false)

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/ResultsFile.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/event/model/entity/ResultsFile.java
@@ -21,6 +21,7 @@
 package com.endurancetrio.data.event.model.entity;
 
 import com.endurancetrio.data.common.model.entity.BaseEntity;
+import com.endurancetrio.data.competitor.model.enumerator.AgeGroup;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.SequenceGenerator;
@@ -47,7 +48,7 @@ import java.util.StringJoiner;
  *     {@link #getSubtitle() subtitle} : the subtitle of the {@link Race}. If the
  *     {@link Race#getGenderCategory() genderCategory} alone is sufficient to distinguish the race,
  *     it is used as the {@link #getSubtitle() subtitle} (e.g., "Women"). Otherwise, both the
- *     {@link Race#getAgeGroup() ageGroup} and the {@link Race#getGenderCategory() genderCategory}
+ *     {@link AgeGroup age group} and the {@link Race#getGenderCategory() genderCategory}
  *     are included (e.g., "Elite Women").
  *   </li>
  *   <li>

--- a/endurancetrio-data/src/main/java/com/endurancetrio/data/tracker/repository/DeviceTelemetryRepository.java
+++ b/endurancetrio-data/src/main/java/com/endurancetrio/data/tracker/repository/DeviceTelemetryRepository.java
@@ -64,7 +64,7 @@ public interface DeviceTelemetryRepository extends
    * B      | 2024-01-05 10:00 | true   | 200  ← Same timestamp as A
    * B      | 2024-01-03 08:00 | true   | 250
    * </pre>
-   * Returns: [A(2024-01-05 10:00), B(2024-01-05 10:00)]</p>
+   * Returns: [A(2024-01-05 10:00), B(2024-01-05 10:00)]
    *
    * @param devices the list of device identifiers to query (must not be null)
    * @return a non-null list containing the most recent active telemetry record for each device in

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/AuditableEntityTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/AuditableEntityTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADDITION
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.common.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link AuditableEntity} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and constructor, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class AuditableEntityTest {
+
+  private AuditableEntity underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new AuditableEntity() {
+    };
+  }
+  @Test
+  void fieldsShouldBeNullByDefault() {
+
+    assertNull(underTest.getVersion());
+    assertNull(underTest.getCreatedAt());
+    assertNull(underTest.getUpdatedAt());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/AuditableEntityTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/AuditableEntityTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADDITION
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.common.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link AuditableEntity} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and constructor, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class AuditableEntityTest {
+
+  private AuditableEntity underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new AuditableEntity() {
+    };
+  }
+  @Test
+  void fieldsShouldBeNullByDefault() {
+
+    assertNull(underTest.getVersion());
+    assertNull(underTest.getCreatedAt());
+    assertNull(underTest.getUpdatedAt());
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/BaseEntityTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/BaseEntityTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.common.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link BaseEntity} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and constructor, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class BaseEntityTest {
+
+  private static final Long ID = 1L;
+
+  private UnderTest underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new UnderTest();
+    underTest.setId(ID);
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+
+    assertEquals(ID, underTest.getId());
+  }
+
+  private static class UnderTest extends BaseEntity<Long> {
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/BaseEntityTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/common/model/entity/BaseEntityTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025-2025 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio Tracker project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.common.model.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link BaseEntity} entity.
+ * <p>
+ * This test may seem redundant since it only verify getters and constructor, but its purpose is to
+ * establish a testing culture from the very beginning of the project. It serves as a reminder that
+ * every part of the application should be testable and that tests should always be present.
+ */
+class BaseEntityTest {
+
+  private static final Long ID = 1L;
+
+  private UnderTest underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new UnderTest();
+    underTest.setId(ID);
+  }
+
+  @Test
+  void entityShouldRetainValues() {
+
+    assertEquals(ID, underTest.getId());
+  }
+
+  private static class UnderTest extends BaseEntity<Long> {
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/AgeGroupConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/AgeGroupConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.competitor.model.enumerator.AgeGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link AgeGroupConverter} converter.
+ */
+class AgeGroupConverterTest {
+
+  private AgeGroupConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new AgeGroupConverter();
+  }
+
+  @Test
+  void shouldConvertAgeGroupToDatabaseColumn() {
+    assertEquals("OPEN", underTest.convertToDatabaseColumn(AgeGroup.OPEN));
+    assertEquals("SEN", underTest.convertToDatabaseColumn(AgeGroup.SEN));
+    assertEquals("ELITE", underTest.convertToDatabaseColumn(AgeGroup.ELITE));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullAgeGroupToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToAgeGroup() {
+    assertEquals(AgeGroup.OPEN, underTest.convertToEntityAttribute("OPEN"));
+    assertEquals(AgeGroup.SEN, underTest.convertToEntityAttribute("SEN"));
+    assertEquals(AgeGroup.ELITE, underTest.convertToEntityAttribute("ELITE"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID")
+    );
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/AthleteGenderConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/AthleteGenderConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.competitor.model.enumerator.AthleteGender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link AthleteGenderConverter} converter.
+ */
+class AthleteGenderConverterTest {
+
+  private AthleteGenderConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new AthleteGenderConverter();
+  }
+
+  @Test
+  void shouldConvertAthleteGenderToDatabaseColumn() {
+    assertEquals("MALE", underTest.convertToDatabaseColumn(AthleteGender.MALE));
+    assertEquals("FEMALE", underTest.convertToDatabaseColumn(AthleteGender.FEMALE));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullAthleteGenderToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToAthleteGender() {
+    assertEquals(AthleteGender.MALE, underTest.convertToEntityAttribute("MALE"));
+    assertEquals(AthleteGender.FEMALE, underTest.convertToEntityAttribute("FEMALE"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/CountryConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/CountryConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.competitor.model.enumerator.Country;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link CountryConverter} converter.
+ */
+class CountryConverterTest {
+
+  private CountryConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new CountryConverter();
+  }
+
+  @Test
+  void shouldConvertCountryToDatabaseColumn() {
+    assertEquals("POR", underTest.convertToDatabaseColumn(Country.POR));
+    assertEquals("USA", underTest.convertToDatabaseColumn(Country.USA));
+    assertEquals("GBR", underTest.convertToDatabaseColumn(Country.GBR));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullCountryToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToCountry() {
+    assertEquals(Country.POR, underTest.convertToEntityAttribute("POR"));
+    assertEquals(Country.USA, underTest.convertToEntityAttribute("USA"));
+    assertEquals(Country.GBR, underTest.convertToEntityAttribute("GBR"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/ParaClassConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/competitor/model/converter/ParaClassConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.competitor.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.competitor.model.enumerator.ParaClass;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link ParaClassConverter} converter.
+ */
+class ParaClassConverterTest {
+
+  private ParaClassConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new ParaClassConverter();
+  }
+
+  @Test
+  void shouldConvertParaClassToDatabaseColumn() {
+    assertEquals("PTVI", underTest.convertToDatabaseColumn(ParaClass.WT_PTVI));
+    assertEquals("PTWC", underTest.convertToDatabaseColumn(ParaClass.WT_PTWC));
+    assertEquals("PTS4", underTest.convertToDatabaseColumn(ParaClass.WT_PTS4));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullParaClassToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToParaClass() {
+    assertEquals(ParaClass.WT_PTVI, underTest.convertToEntityAttribute("PTVI"));
+    assertEquals(ParaClass.WT_PTWC, underTest.convertToEntityAttribute("PTWC"));
+    assertEquals(ParaClass.WT_PTS4, underTest.convertToEntityAttribute("PTS4"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/DistanceTypeConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/DistanceTypeConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.DistanceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link DistanceTypeConverter} converter.
+ */
+class DistanceTypeConverterTest {
+
+  private DistanceTypeConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new DistanceTypeConverter();
+  }
+
+  @Test
+  void shouldConvertDistanceTypeToDatabaseColumn() {
+    assertEquals("ULTRA_MARATHON", underTest.convertToDatabaseColumn(DistanceType.ULTRA_MARATHON));
+    assertEquals("ULTRA_DISTANCE", underTest.convertToDatabaseColumn(DistanceType.ULTRA_DISTANCE));
+    assertEquals("MARATHON", underTest.convertToDatabaseColumn(DistanceType.MARATHON));
+    assertEquals("LONG_DISTANCE", underTest.convertToDatabaseColumn(DistanceType.LONG_DISTANCE));
+    assertEquals("FULL_DISTANCE", underTest.convertToDatabaseColumn(DistanceType.FULL_DISTANCE));
+    assertEquals("HALF_MARATHON", underTest.convertToDatabaseColumn(DistanceType.HALF_MARATHON));
+    assertEquals("MIDDLE_DISTANCE", underTest.convertToDatabaseColumn(DistanceType.MIDDLE_DISTANCE));
+    assertEquals("SHORT_DISTANCE", underTest.convertToDatabaseColumn(DistanceType.SHORT_DISTANCE));
+    assertEquals("STANDARD", underTest.convertToDatabaseColumn(DistanceType.STANDARD));
+    assertEquals("SPRINT", underTest.convertToDatabaseColumn(DistanceType.SPRINT));
+    assertEquals("TEN_KM", underTest.convertToDatabaseColumn(DistanceType.TEN_KM));
+    assertEquals("FIVE_KM", underTest.convertToDatabaseColumn(DistanceType.FIVE_KM));
+    assertEquals("SUPER_SPRINT", underTest.convertToDatabaseColumn(DistanceType.SUPER_SPRINT));
+    assertEquals("YOUTH", underTest.convertToDatabaseColumn(DistanceType.YOUTH));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullDistanceTypeToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToDistanceType() {
+    assertEquals(DistanceType.ULTRA_MARATHON, underTest.convertToEntityAttribute("ULTRA_MARATHON"));
+    assertEquals(DistanceType.ULTRA_DISTANCE, underTest.convertToEntityAttribute("ULTRA_DISTANCE"));
+    assertEquals(DistanceType.MARATHON, underTest.convertToEntityAttribute("MARATHON"));
+    assertEquals(DistanceType.LONG_DISTANCE, underTest.convertToEntityAttribute("LONG_DISTANCE"));
+    assertEquals(DistanceType.FULL_DISTANCE, underTest.convertToEntityAttribute("FULL_DISTANCE"));
+    assertEquals(DistanceType.HALF_MARATHON, underTest.convertToEntityAttribute("HALF_MARATHON"));
+    assertEquals(DistanceType.MIDDLE_DISTANCE, underTest.convertToEntityAttribute("MIDDLE_DISTANCE"));
+    assertEquals(DistanceType.SHORT_DISTANCE, underTest.convertToEntityAttribute("SHORT_DISTANCE"));
+    assertEquals(DistanceType.STANDARD, underTest.convertToEntityAttribute("STANDARD"));
+    assertEquals(DistanceType.SPRINT, underTest.convertToEntityAttribute("SPRINT"));
+    assertEquals(DistanceType.TEN_KM, underTest.convertToEntityAttribute("TEN_KM"));
+    assertEquals(DistanceType.FIVE_KM, underTest.convertToEntityAttribute("FIVE_KM"));
+    assertEquals(DistanceType.SUPER_SPRINT, underTest.convertToEntityAttribute("SUPER_SPRINT"));
+    assertEquals(DistanceType.YOUTH, underTest.convertToEntityAttribute("YOUTH"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/FileTypeConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/FileTypeConverterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.FileType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link FileTypeConverter} converter.
+ */
+class FileTypeConverterTest {
+
+  private FileTypeConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new FileTypeConverter();
+  }
+
+  @Test
+  void shouldConvertFileTypeToDatabaseColumn() {
+    assertEquals("COURSE_MAPS", underTest.convertToDatabaseColumn(FileType.COURSE_MAPS));
+    assertEquals("COVER_IMAGE", underTest.convertToDatabaseColumn(FileType.COVER_IMAGE));
+    assertEquals("GUIDE", underTest.convertToDatabaseColumn(FileType.GUIDE));
+    assertEquals("POSTER", underTest.convertToDatabaseColumn(FileType.POSTER));
+    assertEquals("RULES", underTest.convertToDatabaseColumn(FileType.RULES));
+    assertEquals("START_LIST", underTest.convertToDatabaseColumn(FileType.START_LIST));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullFileTypeToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToFileType() {
+    assertEquals(FileType.COURSE_MAPS, underTest.convertToEntityAttribute("COURSE_MAPS"));
+    assertEquals(FileType.COVER_IMAGE, underTest.convertToEntityAttribute("COVER_IMAGE"));
+    assertEquals(FileType.GUIDE, underTest.convertToEntityAttribute("GUIDE"));
+    assertEquals(FileType.POSTER, underTest.convertToEntityAttribute("POSTER"));
+    assertEquals(FileType.RULES, underTest.convertToEntityAttribute("RULES"));
+    assertEquals(FileType.START_LIST, underTest.convertToEntityAttribute("START_LIST"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/GenderCategoryConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/GenderCategoryConverterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.GenderCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link GenderCategoryConverter} converter.
+ */
+class GenderCategoryConverterTest {
+
+  private GenderCategoryConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new GenderCategoryConverter();
+  }
+
+  @Test
+  void shouldConvertGenderCategoryToDatabaseColumn() {
+    assertEquals("OPEN", underTest.convertToDatabaseColumn(GenderCategory.OPEN));
+    assertEquals("FEMALE", underTest.convertToDatabaseColumn(GenderCategory.FEMALE));
+    assertEquals("MALE", underTest.convertToDatabaseColumn(GenderCategory.MALE));
+    assertEquals("MIXED", underTest.convertToDatabaseColumn(GenderCategory.MIXED));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullGenderCategoryToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToGenderCategory() {
+    assertEquals(GenderCategory.OPEN, underTest.convertToEntityAttribute("OPEN"));
+    assertEquals(GenderCategory.FEMALE, underTest.convertToEntityAttribute("FEMALE"));
+    assertEquals(GenderCategory.MALE, underTest.convertToEntityAttribute("MALE"));
+    assertEquals(GenderCategory.MIXED, underTest.convertToEntityAttribute("MIXED"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/OrganizerTypeConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/OrganizerTypeConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.OrganizerType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link OrganizerTypeConverter} converter.
+ */
+class OrganizerTypeConverterTest {
+
+  private OrganizerTypeConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new OrganizerTypeConverter();
+  }
+
+  @Test
+  void shouldConvertOrganizerTypeToDatabaseColumn() {
+    assertEquals("CLUB", underTest.convertToDatabaseColumn(OrganizerType.CLUB));
+    assertEquals("PRIVATE", underTest.convertToDatabaseColumn(OrganizerType.PRIVATE));
+    assertEquals("PUBLIC", underTest.convertToDatabaseColumn(OrganizerType.PUBLIC));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullOrganizerTypeToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToOrganizerType() {
+    assertEquals(OrganizerType.CLUB, underTest.convertToEntityAttribute("CLUB"));
+    assertEquals(OrganizerType.PRIVATE, underTest.convertToEntityAttribute("PRIVATE"));
+    assertEquals(OrganizerType.PUBLIC, underTest.convertToEntityAttribute("PUBLIC"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/RaceStatusConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/RaceStatusConverterTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.RaceStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RaceStatusConverter} converter.
+ */
+class RaceStatusConverterTest {
+
+  private RaceStatusConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RaceStatusConverter();
+  }
+
+  @Test
+  void shouldConvertRaceStatusToDatabaseColumn() {
+    assertEquals("PLANNED", underTest.convertToDatabaseColumn(RaceStatus.PLANNED));
+    assertEquals("COMPLETED", underTest.convertToDatabaseColumn(RaceStatus.COMPLETED));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullRaceStatusToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToRaceStatus() {
+    assertEquals(RaceStatus.PLANNED, underTest.convertToEntityAttribute("PLANNED"));
+    assertEquals(RaceStatus.COMPLETED, underTest.convertToEntityAttribute("COMPLETED"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/RaceTypeConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/RaceTypeConverterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.RaceType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link RaceTypeConverter} converter.
+ */
+class RaceTypeConverterTest {
+
+  private RaceTypeConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new RaceTypeConverter();
+  }
+
+  @Test
+  void shouldConvertRaceTypeToDatabaseColumn() {
+    assertEquals("INDIVIDUAL_PARENT", underTest.convertToDatabaseColumn(RaceType.INDIVIDUAL_PARENT));
+    assertEquals("INDIVIDUAL_DERIVED", underTest.convertToDatabaseColumn(RaceType.INDIVIDUAL_DERIVED));
+    assertEquals("TEAM_BY_RANK", underTest.convertToDatabaseColumn(RaceType.TEAM_BY_RANK));
+    assertEquals("TEAM_BY_TIME", underTest.convertToDatabaseColumn(RaceType.TEAM_BY_TIME));
+    assertEquals("TEAM_BY_POINTS", underTest.convertToDatabaseColumn(RaceType.TEAM_BY_POINTS));
+    assertEquals("TEAM_RELAY_PARENT", underTest.convertToDatabaseColumn(RaceType.TEAM_RELAY_PARENT));
+    assertEquals("TEAM_RELAY_DERIVED", underTest.convertToDatabaseColumn(RaceType.TEAM_RELAY_DERIVED));
+    assertEquals("MIXED_RELAY_PARENT", underTest.convertToDatabaseColumn(RaceType.MIXED_RELAY_PARENT));
+    assertEquals("MIXED_RELAY_DERIVED", underTest.convertToDatabaseColumn(RaceType.MIXED_RELAY_DERIVED));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullRaceTypeToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToRaceType() {
+    assertEquals(RaceType.INDIVIDUAL_PARENT, underTest.convertToEntityAttribute("INDIVIDUAL_PARENT"));
+    assertEquals(RaceType.INDIVIDUAL_DERIVED, underTest.convertToEntityAttribute("INDIVIDUAL_DERIVED"));
+    assertEquals(RaceType.TEAM_BY_RANK, underTest.convertToEntityAttribute("TEAM_BY_RANK"));
+    assertEquals(RaceType.TEAM_BY_TIME, underTest.convertToEntityAttribute("TEAM_BY_TIME"));
+    assertEquals(RaceType.TEAM_BY_POINTS, underTest.convertToEntityAttribute("TEAM_BY_POINTS"));
+    assertEquals(RaceType.TEAM_RELAY_PARENT, underTest.convertToEntityAttribute("TEAM_RELAY_PARENT"));
+    assertEquals(RaceType.TEAM_RELAY_DERIVED, underTest.convertToEntityAttribute("TEAM_RELAY_DERIVED"));
+    assertEquals(RaceType.MIXED_RELAY_PARENT, underTest.convertToEntityAttribute("MIXED_RELAY_PARENT"));
+    assertEquals(RaceType.MIXED_RELAY_DERIVED, underTest.convertToEntityAttribute("MIXED_RELAY_DERIVED"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/SportConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/SportConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.Sport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link SportConverter} converter.
+ */
+class SportConverterTest {
+
+  private SportConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new SportConverter();
+  }
+
+  @Test
+  void shouldConvertSportToDatabaseColumn() {
+    assertEquals("OPEN_WATER", underTest.convertToDatabaseColumn(Sport.OPEN_WATER));
+    assertEquals("ROAD_CYCLING", underTest.convertToDatabaseColumn(Sport.ROAD_CYCLING));
+    assertEquals("MOUNTAIN_BIKING", underTest.convertToDatabaseColumn(Sport.MOUNTAIN_BIKING));
+    assertEquals("ROAD_RUNNING", underTest.convertToDatabaseColumn(Sport.ROAD_RUNNING));
+    assertEquals("TRAIL_RUNNING", underTest.convertToDatabaseColumn(Sport.TRAIL_RUNNING));
+    assertEquals("TRIATHLON", underTest.convertToDatabaseColumn(Sport.TRIATHLON));
+    assertEquals("DUATHLON", underTest.convertToDatabaseColumn(Sport.DUATHLON));
+    assertEquals("AQUATHLON", underTest.convertToDatabaseColumn(Sport.AQUATHLON));
+    assertEquals("AQUABIKE", underTest.convertToDatabaseColumn(Sport.AQUABIKE));
+    assertEquals("CROSS_TRIATHLON", underTest.convertToDatabaseColumn(Sport.CROSS_TRIATHLON));
+    assertEquals("CROSS_DUATHLON", underTest.convertToDatabaseColumn(Sport.CROSS_DUATHLON));
+    assertEquals("BIATHLON", underTest.convertToDatabaseColumn(Sport.BIATHLON));
+    assertEquals("DOUBLE_BIATHLON", underTest.convertToDatabaseColumn(Sport.DOUBLE_BIATHLON));
+    assertEquals("SWIMRUN", underTest.convertToDatabaseColumn(Sport.SWIMRUN));
+  }
+
+  @Test
+  void shouldReturnNullWhenConvertingNullSportToDatabaseColumn() {
+    assertNull(underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToSport() {
+    assertEquals(Sport.OPEN_WATER, underTest.convertToEntityAttribute("OPEN_WATER"));
+    assertEquals(Sport.ROAD_CYCLING, underTest.convertToEntityAttribute("ROAD_CYCLING"));
+    assertEquals(Sport.MOUNTAIN_BIKING, underTest.convertToEntityAttribute("MOUNTAIN_BIKING"));
+    assertEquals(Sport.ROAD_RUNNING, underTest.convertToEntityAttribute("ROAD_RUNNING"));
+    assertEquals(Sport.TRAIL_RUNNING, underTest.convertToEntityAttribute("TRAIL_RUNNING"));
+    assertEquals(Sport.TRIATHLON, underTest.convertToEntityAttribute("TRIATHLON"));
+    assertEquals(Sport.DUATHLON, underTest.convertToEntityAttribute("DUATHLON"));
+    assertEquals(Sport.AQUATHLON, underTest.convertToEntityAttribute("AQUATHLON"));
+    assertEquals(Sport.AQUABIKE, underTest.convertToEntityAttribute("AQUABIKE"));
+    assertEquals(Sport.CROSS_TRIATHLON, underTest.convertToEntityAttribute("CROSS_TRIATHLON"));
+    assertEquals(Sport.CROSS_DUATHLON, underTest.convertToEntityAttribute("CROSS_DUATHLON"));
+    assertEquals(Sport.BIATHLON, underTest.convertToEntityAttribute("BIATHLON"));
+    assertEquals(Sport.DOUBLE_BIATHLON, underTest.convertToEntityAttribute("DOUBLE_BIATHLON"));
+    assertEquals(Sport.SWIMRUN, underTest.convertToEntityAttribute("SWIMRUN"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/WetSuitRuleConverterTest.java
+++ b/endurancetrio-data/src/test/java/com/endurancetrio/data/event/model/converter/WetSuitRuleConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.data.event.model.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.endurancetrio.data.event.model.enumerator.WetsuitRule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the {@link WetSuitRuleConverter} converter.
+ */
+class WetSuitRuleConverterTest {
+
+  private WetSuitRuleConverter underTest;
+
+  @BeforeEach
+  void setUp() {
+    underTest = new WetSuitRuleConverter();
+  }
+
+  @Test
+  void shouldConvertWetsuitRuleToDatabaseColumn() {
+    assertEquals("FORBIDDEN", underTest.convertToDatabaseColumn(WetsuitRule.FORBIDDEN));
+    assertEquals("MANDATORY", underTest.convertToDatabaseColumn(WetsuitRule.MANDATORY));
+    assertEquals("OPTIONAL", underTest.convertToDatabaseColumn(WetsuitRule.OPTIONAL));
+    assertEquals("UNKNOWN", underTest.convertToDatabaseColumn(WetsuitRule.UNKNOWN));
+  }
+
+  @Test
+  void shouldReturnUnknownWhenConvertingNullWetsuitRuleToDatabaseColumn() {
+    assertEquals("UNKNOWN", underTest.convertToDatabaseColumn(null));
+  }
+
+  @Test
+  void shouldConvertCodeToWetsuitRule() {
+    assertEquals(WetsuitRule.FORBIDDEN, underTest.convertToEntityAttribute("FORBIDDEN"));
+    assertEquals(WetsuitRule.MANDATORY, underTest.convertToEntityAttribute("MANDATORY"));
+    assertEquals(WetsuitRule.OPTIONAL, underTest.convertToEntityAttribute("OPTIONAL"));
+    assertEquals(WetsuitRule.UNKNOWN, underTest.convertToEntityAttribute("UNKNOWN"));
+  }
+
+  @Test
+  void shouldThrowExceptionForInvalidCode() {
+    assertThrows(IllegalArgumentException.class,
+        () -> underTest.convertToEntityAttribute("INVALID"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>com.endurancetrio</groupId>
   <artifactId>endurancetrio-tracker</artifactId>
-  <version>0.4.1</version>
+  <version>0.4.2</version>
 
   <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <sonar.organization>endurancecode</sonar.organization>
-    <sonar.cpd.exclusions>**/db/migration/**/*.sql</sonar.cpd.exclusions>
-    <sonar.exclusions>**/db/migration/**/*.sql</sonar.exclusions>
     <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
     <node.version>v24.15.0</node.version>
     <npm.version>11.12.1</npm.version>
@@ -144,7 +142,61 @@
             <doclint>all,-missing</doclint>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.15</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/model/entity/**</exclude>
+                <exclude>**/model/enumerator/**</exclude>
+                <exclude>**/config/**</exclude>
+              </excludes>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.80</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -113,13 +113,63 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <argLine>
+              @{argLine}
               -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/1.17.8/byte-buddy-agent-1.17.8.jar
               -Djdk.instrument.traceUsage=false
               -Xshare:off
             </argLine>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.15</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.80</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,14 +2,14 @@ sonar.projectKey=endurancecode_endurancetrio-tracker
 sonar.host.url=https://sonarcloud.io
 
 # Path to sources
-#sonar.sources=.
+sonar.sources=.
 sonar.exclusions=**/db/migration/**/*.sql
-#sonar.inclusions=
 
 # Path to tests
-#sonar.tests=
-#sonar.test.exclusions=
-#sonar.test.inclusions=
+sonar.tests=.
+
+# Coverage
+sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,12 +4,15 @@ sonar.host.url=https://sonarcloud.io
 # Path to sources
 sonar.sources=.
 sonar.exclusions=**/db/migration/**/*.sql
-#sonar.inclusions=
 
 # Path to tests
-#sonar.tests=
+sonar.tests=.
 #sonar.test.exclusions=
 #sonar.test.inclusions=
+
+# Coverage
+sonar.coverage.exclusions=**/model/entity/**,**/model/enumerator/**,**/config/**
+sonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco/jacoco.xml
 
 # Source encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Description

Integrates [EnduranceTrio Tracker v0.4.2](https://github.com/EnduranceCode/endurancetrio-tracker) into the Community project. This release includes:

- **Tracker domain**: competitor and result database tables, GeoJSON route DTOs, route validation
- **Full test coverage**: 64 new test files across all three modules (app, business, data), bringing app coverage from 72% to 92%
- **Bug fixes**: `LocaleRedirectFilter` now correctly matches `/v3/api-docs` (no trailing slash); `EventWebController` pagination fixture corrected
- **Infrastructure**: SonarCloud properties, Maven plugin configuration, updated `AGENTS.md` and `docs/development.md`

## Type of Change

- [x] New feature
- [x] Refactoring / code cleanup
- [ ] Build / tooling / CI
- [ ] Documentation
- [ ] Translation / language

## How Has This Been Tested?

- `./mvnw clean install` — 166 tests pass (0 failures, 0 errors) across all modules
- JaCoCo: 92% line coverage (692/745) in `endurancetrio-app`
- All blocker-level test regressions from the previous baseline resolved

## Checklist

- [x] My code follows the project's code style and conventions (see `docs/development.md#code--naming-conventions` and `AGENTS.md#key-conventions`)
- [x] The build runs successfully (`./mvnw clean install`)
- [x] I have updated the documentation (`AGENTS.md`, `README.md`, `docs/`, `DATABASE.md`, etc.) if needed
- [x] The commit messages follow the project's convention (50-char subject, 72-char body wrap)