### PR TITLE
Enhance public pages with dynamic SEO metadata and JSON-LD

### DIFF
--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/common/model/PageMetadata.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/common/model/PageMetadata.java
@@ -23,8 +23,8 @@ package com.endurancetrio.app.common.model;
 /**
  * The {@link PageMetadata} class holds page-level metadata used across shared template fragments in
  * the application. This includes HTML {@code <head>} elements (title, description, canonical URL,
- * Open Graph tags) as well as view-specific data consumed by other layout components such as the
- * navigation bar and footer.
+ * Open Graph tags), JSON-LD structured data payloads, as well as view-specific data consumed by
+ * other layout components such as the navigation bar and footer.
  */
 public class PageMetadata {
 
@@ -36,6 +36,7 @@ public class PageMetadata {
   private String googleAdsenseId;
   private String hreflangUrlEn;
   private String hreflangUrlPt;
+  private String jsonLd;
   private String kofiUserId;
   private String ogImage;
   private Integer ogImageHeight;
@@ -118,6 +119,14 @@ public class PageMetadata {
 
   public void setKofiUserId(String kofiUserId) {
     this.kofiUserId = kofiUserId;
+  }
+
+  public String getJsonLd() {
+    return jsonLd;
+  }
+
+  public void setJsonLd(String jsonLd) {
+    this.jsonLd = jsonLd;
   }
 
   public String getOgImage() {

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/common/utils/JsonLdUtils.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/common/utils/JsonLdUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.utils;
+
+import com.endurancetrio.app.common.model.PageMetadata;
+import com.endurancetrio.business.insight.dto.ArticleDTO;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * The {@link JsonLdUtils} class provides utility methods for building JSON-LD structured data
+ * payloads rendered inside HTML {@code <script type="application/ld+json">} elements by shared
+ * template fragments.
+ */
+public final class JsonLdUtils {
+
+  private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+  private JsonLdUtils() {
+    throw new IllegalStateException("Utility Class");
+  }
+
+  /**
+   * Builds the schema.org {@code Article} JSON-LD payload for the given article, ready to be
+   * embedded in an {@code <script type="application/ld+json">} element. The {@code datePublished}
+   * property is omitted when the article has no published date, since an empty value would fail
+   * structured-data validation.
+   *
+   * @param article  the article to describe
+   * @param metadata the page metadata providing the canonical URL and default Open Graph image
+   * @param baseUrl  the application base URL used to resolve relative featured image URLs
+   * @return a serialized JSON-LD string describing the article
+   */
+  public static String buildArticleJsonLd(ArticleDTO article, PageMetadata metadata, String baseUrl) {
+    boolean hasMetaDescription = article.metaDescription() != null && !article.metaDescription().isBlank();
+    boolean hasFeaturedImage = article.featuredImage() != null && !article.featuredImage().isBlank();
+
+    var node = JSON_MAPPER.createObjectNode();
+    node.put("@context", "https://schema.org");
+    node.put("@type", "Article");
+    node.put("headline", article.title());
+    node.put("description", hasMetaDescription ? article.metaDescription() : article.introText());
+    node.put("url", metadata.getCanonicalUrl());
+    node.put("inLanguage", article.locale());
+    node.putObject("author").put("@type", "Person").put("name", article.authorName());
+    if (article.publishedDate() != null) {
+      node.put("datePublished", article.publishedDate().toLocalDate().toString());
+    }
+    node.put("image", hasFeaturedImage ? baseUrl + article.featuredImage() : metadata.getOgImage());
+
+    return JSON_MAPPER.writeValueAsString(node);
+  }
+}

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/competitor/web/AthleteWebController.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/competitor/web/AthleteWebController.java
@@ -30,6 +30,7 @@ import com.endurancetrio.app.common.model.PageMetadata;
 import com.endurancetrio.app.common.service.MessageService;
 import com.endurancetrio.app.common.utils.PageMetadataUtils;
 import com.endurancetrio.app.config.AppProperties;
+import com.endurancetrio.business.competitor.dto.AthleteDTO;
 import com.endurancetrio.business.competitor.dto.AthleteRacesPageDTO;
 import com.endurancetrio.business.competitor.dto.AthletesPageDTO;
 import com.endurancetrio.business.competitor.service.AthleteService;
@@ -133,10 +134,15 @@ public class AthleteWebController {
   ) {
     Locale locale = "pt".equalsIgnoreCase(language) ? LOCALE_PORTUGUESE : Locale.ENGLISH;
 
+    AthleteDTO athlete = athleteService.getAthleteById(id);
+
     PageMetadata metadata = PageMetadataUtils.create(VIEW_ATHLETE_PROFILE,
-        messageService.getMessage("page.athlete.profile.metadata.title", null, locale),
-        messageService.getMessage("page.athlete.profile.metadata.description", null, locale),
-        request, appProperties
+        messageService.getMessage("page.athlete.profile.metadata.title",
+            new Object[]{athlete.knownName()}, locale
+        ),
+        messageService.getMessage("page.athlete.profile.metadata.description",
+            new Object[]{athlete.knownName()}, locale
+        ), request, appProperties
     );
 
     int clampedPage = Math.max(0, page);
@@ -150,7 +156,7 @@ public class AthleteWebController {
     model.addAttribute(METADATA, metadata);
     model.addAttribute(PAGINATION, athleteRaces.pagination());
     model.addAttribute(ATTRIBUTE_ARTICLES, athleteArticles.articles());
-    model.addAttribute(ATTRIBUTE_ATHLETE, athleteService.getAthleteById(id));
+    model.addAttribute(ATTRIBUTE_ATHLETE, athlete);
     model.addAttribute(ATTRIBUTE_RACES, athleteRaces.races());
 
     return VIEW_ATHLETE_PROFILE;

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/event/web/EventWebController.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/event/web/EventWebController.java
@@ -160,9 +160,12 @@ public class EventWebController {
     Locale locale = "pt".equalsIgnoreCase(language) ? LOCALE_PORTUGUESE : Locale.ENGLISH;
 
     PageMetadata metadata = PageMetadataUtils.create(VIEW_EVENTS_BY_YEAR,
-        messageService.getMessage("page.events.year.metadata.title", null, locale),
-        messageService.getMessage("page.events.year.metadata.description", null, locale), request,
-        appProperties
+        messageService.getMessage("page.events.year.metadata.title",
+            new Object[]{String.valueOf(year)}, locale
+        ),
+        messageService.getMessage("page.events.year.metadata.description",
+            new Object[]{String.valueOf(year)}, locale
+        ), request, appProperties
     );
 
     int clampedPage = Math.max(0, page);
@@ -198,9 +201,11 @@ public class EventWebController {
 
     EventOverviewDTO event = eventService.getEventOverview(id, year);
 
+    Object[] messageArgs = {event.title(), String.valueOf(year)};
+
     PageMetadata metadata = PageMetadataUtils.create(VIEW_EVENT_INSIGHTS,
-        messageService.getMessage("page.event.insights.metadata.title", new Object[]{event.title()}, locale),
-        messageService.getMessage("page.event.insights.metadata.description", new Object[]{event.title()}, locale),
+        messageService.getMessage("page.event.insights.metadata.title", messageArgs, locale),
+        messageService.getMessage("page.event.insights.metadata.description", messageArgs, locale),
         request, appProperties
     );
 
@@ -242,13 +247,15 @@ public class EventWebController {
   ) {
     Locale locale = "pt".equalsIgnoreCase(language) ? LOCALE_PORTUGUESE : Locale.ENGLISH;
 
-    PageMetadata metadata = PageMetadataUtils.create(VIEW_EVENT_OVERVIEW,
-        messageService.getMessage("page.event.overview.metadata.title", null, locale),
-        messageService.getMessage("page.event.overview.metadata.description", null, locale), request,
-        appProperties
-    );
-
     EventOverviewDTO event = eventService.getEventOverview(id, year);
+
+    Object[] messageArgs = {event.title(), String.valueOf(year), event.city()};
+
+    PageMetadata metadata = PageMetadataUtils.create(VIEW_EVENT_OVERVIEW,
+        messageService.getMessage("page.event.overview.metadata.title", messageArgs, locale),
+        messageService.getMessage("page.event.overview.metadata.description", messageArgs, locale),
+        request, appProperties
+    );
 
     long articlesCount = insightService.getArticlesCountByEvent(id);
 
@@ -278,12 +285,6 @@ public class EventWebController {
   ) {
     Locale locale = "pt".equalsIgnoreCase(language) ? LOCALE_PORTUGUESE : Locale.ENGLISH;
 
-    PageMetadata metadata = PageMetadataUtils.create(VIEW_RACE_RESULTS,
-        messageService.getMessage("page.event.results.metadata.title", null, locale),
-        messageService.getMessage("page.event.results.metadata.description", null, locale),
-        request, appProperties
-    );
-
     EventOverviewDTO event = eventService.getEventOverview(eventId, year);
 
     List<RaceDTO> races = event.races();
@@ -299,6 +300,14 @@ public class EventWebController {
           LOG.warn(errorMsg);
           return new EnduranceTrioException(new ErrorDTO(EnduranceTrioError.NOT_FOUND, errorMsg));
         });
+
+    Object[] messageArgs = {currentRace.title(), event.title(), String.valueOf(year)};
+
+    PageMetadata metadata = PageMetadataUtils.create(VIEW_RACE_RESULTS,
+        messageService.getMessage("page.event.results.metadata.title", messageArgs, locale),
+        messageService.getMessage("page.event.results.metadata.description", messageArgs, locale),
+        request, appProperties
+    );
 
     RaceResultsDTO raceResults = raceService.getRaceResults(currentRace);
     Set<String> activeColumns = computeActiveColumns(raceResults);

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/insight/web/InsightsWebController.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/insight/web/InsightsWebController.java
@@ -28,6 +28,7 @@ import static com.endurancetrio.app.common.constants.AppConstants.PAGINATION;
 import com.endurancetrio.app.common.annotation.EnduranceTrioWebController;
 import com.endurancetrio.app.common.model.PageMetadata;
 import com.endurancetrio.app.common.service.MessageService;
+import com.endurancetrio.app.common.utils.JsonLdUtils;
 import com.endurancetrio.app.common.utils.PageMetadataUtils;
 import com.endurancetrio.app.config.AppProperties;
 import com.endurancetrio.business.insight.dto.ArticleDTO;
@@ -126,14 +127,15 @@ public class InsightsWebController {
     String metaTitle = (article.metaTitle() != null && !article.metaTitle().isBlank())
         ? article.metaTitle() + BRAND_SUFFIX
         : article.title() + BRAND_SUFFIX;
-    String metaDescription =
-        (article.metaDescription() != null && !article.metaDescription().isBlank())
+
+    String metaDescription = (article.metaDescription() != null && !article.metaDescription().isBlank())
             ? article.metaDescription()
             : article.introText();
 
     PageMetadata metadata = PageMetadataUtils.create(VIEW_INSIGHT_ARTICLE, metaTitle,
         metaDescription, request, appProperties
     );
+    metadata.setJsonLd(JsonLdUtils.buildArticleJsonLd(article, metadata, PageMetadataUtils.getBaseUrl(request)));
 
     model.addAttribute(LANGUAGE, locale.getLanguage());
     model.addAttribute(METADATA, metadata);

--- a/endurancetrio-app/src/main/java/com/endurancetrio/app/insight/web/InsightsWebController.java
+++ b/endurancetrio-app/src/main/java/com/endurancetrio/app/insight/web/InsightsWebController.java
@@ -55,6 +55,8 @@ public class InsightsWebController {
   private static final String ATTRIBUTE_ARTICLE = "article";
   private static final String ATTRIBUTE_ARTICLES = "articles";
 
+  private static final String BRAND_SUFFIX = " | EnduranceTrio";
+
   private static final int PAGE_SIZE = 10;
 
   private final MessageService messageService;
@@ -120,11 +122,17 @@ public class InsightsWebController {
     Locale locale = "pt".equalsIgnoreCase(language) ? LOCALE_PORTUGUESE : Locale.ENGLISH;
 
     ArticleDTO article = insightService.getArticleBySlug(slug, locale);
-    String metaTitle = article.metaTitle() != null ? article.metaTitle() : article.title();
+
+    String metaTitle = (article.metaTitle() != null && !article.metaTitle().isBlank())
+        ? article.metaTitle() + BRAND_SUFFIX
+        : article.title() + BRAND_SUFFIX;
+    String metaDescription =
+        (article.metaDescription() != null && !article.metaDescription().isBlank())
+            ? article.metaDescription()
+            : article.introText();
 
     PageMetadata metadata = PageMetadataUtils.create(VIEW_INSIGHT_ARTICLE, metaTitle,
-        messageService.getMessage("page.insights.detail.metadata.description", null, locale),
-        request, appProperties
+        metaDescription, request, appProperties
     );
 
     model.addAttribute(LANGUAGE, locale.getLanguage());

--- a/endurancetrio-app/src/main/resources/messages.properties
+++ b/endurancetrio-app/src/main/resources/messages.properties
@@ -68,13 +68,13 @@ navbar.option.mission=Mission
 # Pages
 page.athlete.profile.empty=No races found for this athlete
 page.athlete.profile.insights.title=Insights
-page.athlete.profile.metadata.description=View athlete profile and race history
-page.athlete.profile.metadata.title=Athlete Profile - EnduranceTrio
+page.athlete.profile.metadata.description=Explore {0}'s competition history, race results, and published articles on EnduranceTrio.
+page.athlete.profile.metadata.title={0} - Athlete Profile & Race History | EnduranceTrio
 page.athlete.profile.races.title=Races
 
 page.athletes.empty=No athletes found
-page.athletes.metadata.description=Browse the endurance sports athletes
-page.athletes.metadata.title=Athletes - EnduranceTrio
+page.athletes.metadata.description=Explore athletes who competed in endurance sports events in Portugal, with an initial focus on Portuguese triathlon records from 1984 onward.
+page.athletes.metadata.title=Athletes Directory | EnduranceTrio
 page.athletes.subtitle=Profiles, races, and results
 page.athletes.title=Athletes
 
@@ -88,15 +88,15 @@ page.error.500.metadata.description=An internal server error occurred
 page.error.500.metadata.title=500 Internal Server Error - EnduranceTrio
 page.error.500.title=Mechanical Failure: Internal Server Error
 
-page.event.insights.metadata.description=Articles related to {0}
-page.event.insights.metadata.title=Insights about {0} - EnduranceTrio
+page.event.insights.metadata.description=Read perspectives, race accounts, and first-person stories from athletes and organizers of {0} ({1}).
+page.event.insights.metadata.title={0} ({1}) Stories & Insights | EnduranceTrio
 page.event.insights.title=Insights
 page.event.overview.label.organizers=Organizers
-page.event.overview.metadata.description=View endurance sports event details
-page.event.overview.metadata.title=Event Details - EnduranceTrio
+page.event.overview.metadata.description=Event details, organizers, and associated races for {0} ({1}) in {2}. Access race details and official results.
+page.event.overview.metadata.title={0} ({1}) — Overview & Info | EnduranceTrio
 page.event.overview.section.support=Help us complete the archive
-page.event.results.metadata.description=View endurance sports event results
-page.event.results.metadata.title=Results - EnduranceTrio
+page.event.results.metadata.description=Official race results and category classifications for {0} at {1} ({2}). Finish times, splits, and athlete rankings.
+page.event.results.metadata.title={0} Results — {1} ({2}) | EnduranceTrio
 page.event.results.label.ageGroup=Age Group
 page.event.results.label.athlete=Athlete
 page.event.results.label.bib=Bib
@@ -125,38 +125,36 @@ page.event.tab.insights=Insights
 page.event.tab.overview=Overview
 page.event.tab.results=Results
 
-page.events.metadata.description=Browse endurance sports events
-page.events.metadata.title=Events - EnduranceTrio
+page.events.metadata.description=Browse endurance sports events held in Portugal, organized by competition year, with an initial focus on triathlon and duathlon.
+page.events.metadata.title=Events Directory | EnduranceTrio
 page.events.title=Events
 page.events.year.empty=No events found for {0}
-page.events.year.metadata.description=Browse the endurance sports events by year
-page.events.year.metadata.title=Events by year - EnduranceTrio
+page.events.year.metadata.description=Browse endurance sports events held in Portugal during {0}. Explore event details, races, and results.
+page.events.year.metadata.title={0} Triathlon and Endurance Sports Events | EnduranceTrio
 page.events.year.title=Events in {0}
 
 page.home.button.events=All Events
 page.home.button.explore=Explore
 page.home.button.mission=Mission
-page.home.featured-articles.title=The pioneer's insight
-page.home.latest-events.subtitle=The latest multisport and triathlon events added to our archive.
+page.home.featured-articles.title=Insights from the Pioneers
+page.home.latest-events.subtitle=The latest triathlon and endurance sports events added to EnduranceTrio.
 page.home.latest-events.title=Recently Added Events
 page.home.latest-results.subtitle=The latest race and competition results processed and added to our database.
 page.home.latest-results.title=Recently Added Results
-page.home.metadata.description=The central hub for endurance sports data and resources
-page.home.metadata.title=Home - EnduranceTrio
+page.home.metadata.description=A reference for triathlon and endurance sports in Portugal, connecting events, athletes, results, and insights. Starting with triathlon records from 1984.
+page.home.metadata.title=EnduranceTrio | Triathlon and Endurance Sports in Portugal
 
 page.insights.detail.language.english=English
 page.insights.detail.language.note=This article is only available in {0}
 page.insights.detail.language.portuguese=Portuguese
-page.insights.detail.metadata.description=View the full article
-page.insights.detail.metadata.title={0} - Insights - EnduranceTrio
 page.insights.detail.read.more=Read more
 page.insights.empty=No articles found yet
-page.insights.metadata.description=Analysis, race reports and perspectives on endurance sports
-page.insights.metadata.title=Insights - EnduranceTrio
+page.insights.metadata.description=First-person accounts, in-depth analysis, and perspectives from athletes and contributors across triathlon and endurance sports in Portugal.
+page.insights.metadata.title=Triathlon & Endurance Sports Insights | EnduranceTrio
 page.insights.title=Insights
 
-page.mission.metadata.description=The central hub for endurance sports data and resources
-page.mission.metadata.title=Mission - EnduranceTrio
+page.mission.metadata.description=Discover the vision behind EnduranceTrio: connecting and celebrating endurance sports in Portugal through data, stories, and shared knowledge.
+page.mission.metadata.title=Our Mission | EnduranceTrio
 page.mission.title=Mission
 
 page.newsletter.back-home=Return to home
@@ -174,8 +172,8 @@ page.newsletter.newsletter-success.metadata.description=Newsletter subscription 
 page.newsletter.newsletter-success.metadata.title=Check your inbox - EnduranceTrio
 page.newsletter.newsletter-success.title=Almost there!
 
-page.policy.metadata.description=EnduranceTrio privacy and cookies policy
-page.policy.metadata.title=Privacy and Cookies Policy - EnduranceTrio
+page.policy.metadata.description=Learn how EnduranceTrio protects your personal data, handles cookies, and respects visitor privacy in compliance with GDPR regulations.
+page.policy.metadata.title=Privacy and Cookies Policy | EnduranceTrio
 page.policy.section.cookies=Cookies Policy
 page.policy.section.privacy=Privacy Policy
 page.policy.title=Privacy and Cookies Policy

--- a/endurancetrio-app/src/main/resources/messages_pt.properties
+++ b/endurancetrio-app/src/main/resources/messages_pt.properties
@@ -68,13 +68,13 @@ navbar.option.mission=Missão
 # Pages
 page.athlete.profile.empty=Nenhuma prova encontrada para este atleta
 page.athlete.profile.insights.title=Perspetivas
-page.athlete.profile.metadata.description=Ver perfil e histórico de provas do atleta
-page.athlete.profile.metadata.title=Perfil do Atleta - EnduranceTrio
+page.athlete.profile.metadata.description=Consulte o percurso competitivo, os resultados e os artigos publicados por {0} no site EnduranceTrio.
+page.athlete.profile.metadata.title={0} - Perfil do Atleta e Histórico de Provas | EnduranceTrio
 page.athlete.profile.races.title=Provas
 
 page.athletes.empty=Nenhum atleta encontrado
-page.athletes.metadata.description=Explore os atletas de desportos de endurance
-page.athletes.metadata.title=Atletas - EnduranceTrio
+page.athletes.metadata.description=Explore atletas que participaram em eventos de desportos de endurance em Portugal, com um foco inicial no triatlo português a partir de 1984.
+page.athletes.metadata.title=Diretório de Atletas | EnduranceTrio
 page.athletes.subtitle=Perfis, provas e resultados
 page.athletes.title=Atletas
 
@@ -88,15 +88,15 @@ page.error.500.metadata.description=Ocorreu um erro interno do servidor
 page.error.500.metadata.title=500 Erro Interno do Servidor - EnduranceTrio
 page.error.500.title=Falha mecânica: Erro Interno no Servidor
 
-page.event.insights.metadata.description=Artigos relacionados com {0}
-page.event.insights.metadata.title=Perspetivas do {0} - EnduranceTrio
+page.event.insights.metadata.description=Leia relatos na primeira pessoa, histórias e perspetivas de atletas e organizadores sobre {0} ({1}).
+page.event.insights.metadata.title=Perspetivas de {0} ({1}) | EnduranceTrio
 page.event.insights.title=Perspetivas
 page.event.overview.label.organizers=Organizadores
-page.event.overview.metadata.description=Detalhes do evento de desportos de endurance
-page.event.overview.metadata.title=Detalhes do Evento - EnduranceTrio
+page.event.overview.metadata.description=Detalhes do evento, organizadores e provas associadas a {0} ({1}), em {2}. Consulte informações das provas e resultados oficiais.
+page.event.overview.metadata.title={0} ({1}) - Detalhes do Evento | EnduranceTrio
 page.event.overview.section.support=Ajude-nos a completar o arquivo
-page.event.results.metadata.description=Resultados de eventos de desportos de endurance
-page.event.results.metadata.title=Resultados - EnduranceTrio
+page.event.results.metadata.description=Classificações e resultados oficiais da prova {0}, realizada no evento {1} ({2}). Tempos finais, parciais e escalões dos atletas.
+page.event.results.metadata.title=Resultados de {0} — {1} ({2}) | EnduranceTrio
 page.event.results.label.ageGroup=Escalão
 page.event.results.label.athlete=Atleta
 page.event.results.label.bib=Dorsal
@@ -125,38 +125,36 @@ page.event.tab.insights=Perspetivas
 page.event.tab.overview=Geral
 page.event.tab.results=Resultados
 
-page.events.metadata.description=Explore eventos de desportos de endurance
-page.events.metadata.title=Eventos - EnduranceTrio
+page.events.metadata.description=Consulte eventos de desportos de endurance realizados em Portugal, organizados por ano, com um foco inicial no triatlo e duatlo.
+page.events.metadata.title=Listagem de Eventos | EnduranceTrio
 page.events.title=Eventos
 page.events.year.empty=Nenhum evento encontrado para {0}
-page.events.year.metadata.description=Explore eventos de desportos de endurance por ano
-page.events.year.metadata.title=Eventos por ano - EnduranceTrio
+page.events.year.metadata.description=Explore eventos de desportos de endurance realizados em Portugal durante {0}. Consulte detalhes, provas e resultados.
+page.events.year.metadata.title=Eventos de Triatlo e Desportos de Endurance em {0} | EnduranceTrio
 page.events.year.title=Eventos de {0}
 
 page.home.button.events=Todos os Eventos
 page.home.button.explore=Explorar
 page.home.button.mission=Missão
-page.home.featured-articles.title=A perspetiva dos pioneiros
-page.home.latest-events.subtitle=Os eventos de triatlo e multidesporto adicionados mais recentemente ao nosso arquivo.
+page.home.featured-articles.title=Perspetivas dos pioneiros
+page.home.latest-events.subtitle=Os eventos de triatlo e desportos de endurance adicionados mais recentemente ao site EnduranceTrio.
 page.home.latest-events.title=Eventos Adicionados Recentemente
 page.home.latest-results.subtitle=Os resultados de provas e competições processados e adicionados mais recentemente à nossa base de dados.
 page.home.latest-results.title=Resultados Adicionados Recentemente
-page.home.metadata.description=A plataforma central para dados e recursos de desportos de endurance
-page.home.metadata.title=Início - EnduranceTrio
+page.home.metadata.description=Referência de triatlo e desportos de endurance em Portugal, ligando provas, atletas, resultados e perspetivas. Registos de triatlo a partir de 1984.
+page.home.metadata.title=EnduranceTrio | Triatlo e Desportos de Endurance em Portugal
 
 page.insights.detail.language.english=Inglês
 page.insights.detail.language.note=Este artigo está disponível apenas em {0}
 page.insights.detail.language.portuguese=Português
-page.insights.detail.metadata.description=Ver o artigo completo
-page.insights.detail.metadata.title={0} - Perspetivas - EnduranceTrio
 page.insights.detail.read.more=Ler mais
 page.insights.empty=Ainda não foram publicados artigos
-page.insights.metadata.description=Análises, relatos de provas e perspetivas sobre desportos de endurance
-page.insights.metadata.title=Perspetivas - EnduranceTrio
+page.insights.metadata.description=Relatos na primeira pessoa, análises e perspetivas de atletas e intervenientes no triatlo e nos desportos de endurance em Portugal.
+page.insights.metadata.title=Perspetivas sobre Triatlo e Endurance | EnduranceTrio
 page.insights.title=Perspetivas
 
-page.mission.metadata.description=A plataforma central para dados e recursos de desportos de endurance
-page.mission.metadata.title=Missão - EnduranceTrio
+page.mission.metadata.description=Conheça a visão da EnduranceTrio: ligar e celebrar os desportos de endurance em Portugal com dados, histórias e conhecimento partilhado.
+page.mission.metadata.title=A Nossa Missão | EnduranceTrio
 page.mission.title=Missão
 
 page.newsletter.back-home=Voltar ao início
@@ -174,8 +172,8 @@ page.newsletter.newsletter-success.metadata.description=Subscrição de newslett
 page.newsletter.newsletter-success.metadata.title=Verifique a sua caixa de correio - EnduranceTrio
 page.newsletter.newsletter-success.title=Já falta pouco!
 
-page.policy.metadata.description=Política de Privacidade e Cookies da EnduranceTrio
-page.policy.metadata.title=Política de Privacidade e Cookies - EnduranceTrio
+page.policy.metadata.description=Saiba como a EnduranceTrio protege os seus dados pessoais, gere cookies e garante a privacidade dos utilizadores em conformidade com o RGPD.
+page.policy.metadata.title=Política de Privacidade e Cookies | EnduranceTrio
 page.policy.section.cookies=Política de Cookies
 page.policy.section.privacy=Política de Privacidade
 page.policy.title=Política de Privacidade e Cookies

--- a/endurancetrio-app/src/main/resources/templates/fragments/head.html
+++ b/endurancetrio-app/src/main/resources/templates/fragments/head.html
@@ -67,6 +67,11 @@
   <link rel="icon" data-th-href="@{/favicon.svg}" type="image/svg+xml">
   <link rel="apple-touch-icon" data-th-href="@{/apple-touch-icon.png}">
 
+  <!-- JSON-LD structured data, serialized server-side (see JsonLdUtils) -->
+  <script type="application/ld+json" data-th-if="${metadata.jsonLd != null}"
+          data-th-utext="${metadata.jsonLd}">
+  </script>
+
   <link rel="stylesheet" data-th-href="@{/css/style.css}">
   <script defer="defer" data-th-src="@{/js/script.js}"></script>
 

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/common/utils/JsonLdUtilsTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/common/utils/JsonLdUtilsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2011-2026 Ricardo do Canto
+ *
+ * This file is part of the EnduranceTrio project.
+ *
+ * Licensed under the Functional Software License (FSL), Version 1.1, ALv2 Future License
+ * (the "License");
+ *
+ * You may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at https://fsl.software/
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+ * PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+ *
+ * IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+ * SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ * EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+ */
+
+package com.endurancetrio.app.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.endurancetrio.app.common.model.PageMetadata;
+import com.endurancetrio.app.insight.fixtures.ArticleDTOFixtures;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+class JsonLdUtilsTest {
+
+  private static final String BASE_URL = "http://localhost:8080";
+
+  @Test
+  void buildArticleJsonLdShouldSerializeEscapedQuotesApostrophesAndHtml() {
+    JsonNode json = parse(JsonLdUtils.buildArticleJsonLd(
+        ArticleDTOFixtures.withSpecialCharacters(), createMetadata(), BASE_URL));
+
+    assertEquals("https://schema.org", json.get("@context").asString());
+    assertEquals("Article", json.get("@type").asString());
+    assertEquals(ArticleDTOFixtures.SPECIAL_TITLE, json.get("headline").asString());
+    assertEquals(ArticleDTOFixtures.SPECIAL_INTRO_TEXT, json.get("description").asString());
+    assertEquals(BASE_URL + "/en/insights/" + ArticleDTOFixtures.STANDARD_SLUG,
+        json.get("url").asString());
+    assertEquals("en", json.get("inLanguage").asString());
+    assertEquals("Person", json.get("author").get("@type").asString());
+    assertEquals(ArticleDTOFixtures.SPECIAL_AUTHOR_NAME, json.get("author").get("name").asString());
+    assertEquals("2024-06-15", json.get("datePublished").asString());
+  }
+
+  @Test
+  void buildArticleJsonLdShouldPrefixBaseUrlToFeaturedImage() {
+    JsonNode json = parse(JsonLdUtils.buildArticleJsonLd(
+        ArticleDTOFixtures.withFeaturedImage(), createMetadata(), BASE_URL));
+
+    assertEquals(BASE_URL + ArticleDTOFixtures.FEATURED_IMAGE, json.get("image").asString());
+    assertEquals("2024-06-15", json.get("datePublished").asString());
+  }
+
+  @Test
+  void buildArticleJsonLdShouldUseMetaDescriptionWhenPresent() {
+    JsonNode json = parse(JsonLdUtils.buildArticleJsonLd(
+        ArticleDTOFixtures.withMetaTitle(), createMetadata(), BASE_URL));
+
+    assertEquals(ArticleDTOFixtures.META_DESCRIPTION, json.get("description").asString());
+  }
+
+  @Test
+  void buildArticleJsonLdShouldFallBackToIntroTextWhenMetaDescriptionIsBlank() {
+    JsonNode json = parse(JsonLdUtils.buildArticleJsonLd(
+        ArticleDTOFixtures.withBlankMetaDescription(), createMetadata(), BASE_URL));
+
+    assertEquals(ArticleDTOFixtures.STANDARD_INTRO_TEXT, json.get("description").asString());
+  }
+
+  @Test
+  void buildArticleJsonLdShouldOmitDatePublishedWhenNullAndFallBackToDefaultOgImage() {
+    String jsonLd = JsonLdUtils.buildArticleJsonLd(
+        ArticleDTOFixtures.withoutPublishedDate(), createMetadata(), BASE_URL);
+    JsonNode json = parse(jsonLd);
+
+    assertFalse(json.has("datePublished"));
+    assertEquals(BASE_URL + "/img/endurancetrio-open-graph.png", json.get("image").asString());
+  }
+
+  @Test
+  void buildArticleJsonLdShouldFallBackToDefaultOgImageWhenFeaturedImageIsBlank() {
+    JsonNode json = parse(JsonLdUtils.buildArticleJsonLd(
+        ArticleDTOFixtures.withBlankFeaturedImage(), createMetadata(), BASE_URL));
+
+    assertEquals(BASE_URL + "/img/endurancetrio-open-graph.png", json.get("image").asString());
+  }
+
+  private PageMetadata createMetadata() {
+    PageMetadata metadata = new PageMetadata();
+    metadata.setCanonicalUrl(BASE_URL + "/en/insights/race-analysis-2024");
+    metadata.setOgImage(BASE_URL + "/img/endurancetrio-open-graph.png");
+    return metadata;
+  }
+
+  private JsonNode parse(String jsonLd) {
+    return JsonMapper.builder().build().readTree(jsonLd);
+  }
+}

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/competitor/web/AthleteWebControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/competitor/web/AthleteWebControllerTest.java
@@ -391,25 +391,11 @@ class AthleteWebControllerTest {
 
   @Test
   void athleteProfileWhenAthleteNotFound() throws Exception {
-    when(messageService.getMessage(eq("page.athlete.profile.metadata.title"), any(),
-        any()
-    )).thenReturn("Athlete Profile - EnduranceTrio");
-    when(messageService.getMessage(eq("page.athlete.profile.metadata.description"), any(),
-        any()
-    )).thenReturn("View athlete profile and race history");
     when(messageService.getMessage(eq("page.error.404.metadata.title"), any(), any())).thenReturn(
         "Page Not Found");
     when(messageService.getMessage(eq("page.error.404.metadata.description"), any(),
         any()
     )).thenReturn("The requested page was not found");
-    when(athleteService.getAthleteRaces(eq(999L), any())).thenReturn(
-        new AthleteRacesPageDTO(List.of(),
-            new com.endurancetrio.business.common.dto.PaginationDTO(0, 0, 0, false, false)
-        ));
-    when(insightService.getArticlesByAthleteId(eq(999L), any(), any())).thenReturn(
-        new InsightPageDTO(List.of(),
-            new com.endurancetrio.business.common.dto.PaginationDTO(0, 0, 0, false, false)
-        ));
     when(athleteService.getAthleteById(999L)).thenThrow(new EnduranceTrioException(
         new com.endurancetrio.business.common.dto.ErrorDTO(EnduranceTrioError.NOT_FOUND,
             "No athlete found with ID 999"

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/insight/fixtures/ArticleDTOFixtures.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/insight/fixtures/ArticleDTOFixtures.java
@@ -52,6 +52,14 @@ public class ArticleDTOFixtures {
   public static final String META_TITLE = "Race Analysis 2024 - EnduranceTrio Insights";
   public static final String META_DESCRIPTION = "An in-depth analysis of the 2024 race season.";
 
+  public static final String FEATURED_IMAGE = "/img/insights/insights-001.jpg";
+  public static final Integer FEATURED_IMAGE_WIDTH = 1200;
+  public static final Integer FEATURED_IMAGE_HEIGHT = 628;
+
+  public static final String SPECIAL_TITLE = "How a \"poor\" country shaped my journey";
+  public static final String SPECIAL_INTRO_TEXT = "<p>Intro with \"quotes\" & <b>html</b></p>";
+  public static final String SPECIAL_AUTHOR_NAME = "Author O'Brien";
+
   private ArticleDTOFixtures() {
   }
 
@@ -87,6 +95,62 @@ public class ArticleDTOFixtures {
   public static ArticleDTO portuguese() {
     return new ArticleDTO(STANDARD_ID, STANDARD_SLUG, PT_TITLE, null, PT_INTRO_TEXT, null,
         STANDARD_AUTHOR_NAME, STANDARD_PUBLISHED_DATE, null, null, null, null, null, PT_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} with a featured image and its dimensions.
+   *
+   * @return an ArticleDTO instance with a featured image
+   */
+  public static ArticleDTO withFeaturedImage() {
+    return new ArticleDTO(STANDARD_ID, STANDARD_SLUG, STANDARD_TITLE, null, STANDARD_INTRO_TEXT, null,
+        STANDARD_AUTHOR_NAME, STANDARD_PUBLISHED_DATE, FEATURED_IMAGE, FEATURED_IMAGE_WIDTH, FEATURED_IMAGE_HEIGHT,
+        null, null, STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} without a published date.
+   *
+   * @return an ArticleDTO instance without a published date
+   */
+  public static ArticleDTO withoutPublishedDate() {
+    return new ArticleDTO(STANDARD_ID, STANDARD_SLUG, STANDARD_TITLE, null, STANDARD_INTRO_TEXT, null,
+        STANDARD_AUTHOR_NAME, null, null, null, null, null, null, STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} with a meta title and a blank meta description.
+   *
+   * @return an ArticleDTO instance with a blank meta description
+   */
+  public static ArticleDTO withBlankMetaDescription() {
+    return new ArticleDTO(STANDARD_ID, STANDARD_SLUG, STANDARD_TITLE, null, STANDARD_INTRO_TEXT, null,
+        STANDARD_AUTHOR_NAME, STANDARD_PUBLISHED_DATE, null, null, null, META_TITLE, "   ", STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} with a blank featured image.
+   *
+   * @return an ArticleDTO instance with a blank featured image
+   */
+  public static ArticleDTO withBlankFeaturedImage() {
+    return new ArticleDTO(STANDARD_ID, STANDARD_SLUG, STANDARD_TITLE, null, STANDARD_INTRO_TEXT, null,
+        STANDARD_AUTHOR_NAME, STANDARD_PUBLISHED_DATE, "", null, null, null, null, STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} whose text fields contain double quotes, apostrophes and HTML.
+   *
+   * @return an ArticleDTO instance with special characters
+   */
+  public static ArticleDTO withSpecialCharacters() {
+    return new ArticleDTO(STANDARD_ID, STANDARD_SLUG, SPECIAL_TITLE, null, SPECIAL_INTRO_TEXT, null,
+        SPECIAL_AUTHOR_NAME, STANDARD_PUBLISHED_DATE, null, null, null, null, null, STANDARD_LOCALE
     );
   }
 }

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/insight/web/InsightsWebControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/insight/web/InsightsWebControllerTest.java
@@ -148,9 +148,6 @@ class InsightsWebControllerTest {
 
   @Test
   void getInsightDetailPageWithEnglishLocale() throws Exception {
-    when(messageService.getMessage(eq("page.insights.detail.metadata.description"), any(),
-        any()
-    )).thenReturn("Full article view");
     when(insightService.getArticleBySlug(eq(ARTICLE_EN.slug()), any())).thenReturn(ARTICLE_EN);
 
     mockMvc.perform(get("/en/insights/" + ARTICLE_EN.slug()))
@@ -163,9 +160,6 @@ class InsightsWebControllerTest {
 
   @Test
   void getInsightDetailPageWithPortugueseLocale() throws Exception {
-    when(messageService.getMessage(eq("page.insights.detail.metadata.description"), any(),
-        any()
-    )).thenReturn("Visualização completa do artigo");
     when(insightService.getArticleBySlug(eq(ARTICLE_PT.slug()), any())).thenReturn(ARTICLE_PT);
 
     mockMvc.perform(get("/pt/insights/" + ARTICLE_PT.slug()))
@@ -178,29 +172,46 @@ class InsightsWebControllerTest {
 
   @Test
   void getInsightDetailPageMetadataUsesMetaTitle() throws Exception {
-    when(messageService.getMessage(eq("page.insights.detail.metadata.description"), any(),
-        any()
-    )).thenReturn("Full article view");
     when(insightService.getArticleBySlug(eq(ARTICLE_WITH_META.slug()), any())).thenReturn(
         ARTICLE_WITH_META);
 
     mockMvc.perform(get("/en/insights/" + ARTICLE_WITH_META.slug()))
         .andExpect(model().attribute("metadata", org.hamcrest.Matchers.hasProperty("title",
-                org.hamcrest.Matchers.is(ArticleDTOFixtures.META_TITLE)
+                org.hamcrest.Matchers.is(ArticleDTOFixtures.META_TITLE + " | EnduranceTrio")
             )
         ));
   }
 
   @Test
   void getInsightDetailPageMetadataUsesTitleFallback() throws Exception {
-    when(messageService.getMessage(eq("page.insights.detail.metadata.description"), any(),
-        any()
-    )).thenReturn("Full article view");
     when(insightService.getArticleBySlug(eq(ARTICLE_EN.slug()), any())).thenReturn(ARTICLE_EN);
 
     mockMvc.perform(get("/en/insights/" + ARTICLE_EN.slug()))
         .andExpect(model().attribute("metadata", org.hamcrest.Matchers.hasProperty("title",
-                org.hamcrest.Matchers.is(ArticleDTOFixtures.STANDARD_TITLE)
+                org.hamcrest.Matchers.is(ArticleDTOFixtures.STANDARD_TITLE + " | EnduranceTrio")
+            )
+        ));
+  }
+
+  @Test
+  void getInsightDetailPageMetadataUsesMetaDescription() throws Exception {
+    when(insightService.getArticleBySlug(eq(ARTICLE_WITH_META.slug()), any())).thenReturn(
+        ARTICLE_WITH_META);
+
+    mockMvc.perform(get("/en/insights/" + ARTICLE_WITH_META.slug()))
+        .andExpect(model().attribute("metadata", org.hamcrest.Matchers.hasProperty("description",
+                org.hamcrest.Matchers.is(ArticleDTOFixtures.META_DESCRIPTION)
+            )
+        ));
+  }
+
+  @Test
+  void getInsightDetailPageMetadataUsesIntroTextFallback() throws Exception {
+    when(insightService.getArticleBySlug(eq(ARTICLE_EN.slug()), any())).thenReturn(ARTICLE_EN);
+
+    mockMvc.perform(get("/en/insights/" + ARTICLE_EN.slug()))
+        .andExpect(model().attribute("metadata", org.hamcrest.Matchers.hasProperty("description",
+                org.hamcrest.Matchers.is(ArticleDTOFixtures.STANDARD_INTRO_TEXT)
             )
         ));
   }

--- a/endurancetrio-app/src/test/java/com/endurancetrio/app/insight/web/InsightsWebControllerTest.java
+++ b/endurancetrio-app/src/test/java/com/endurancetrio/app/insight/web/InsightsWebControllerTest.java
@@ -20,6 +20,8 @@
 
 package com.endurancetrio.app.insight.web;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -28,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
+import com.endurancetrio.app.common.model.PageMetadata;
 import com.endurancetrio.app.common.service.MessageService;
 import com.endurancetrio.app.config.AppProperties;
 import com.endurancetrio.app.insight.fixtures.ArticleDTOFixtures;
@@ -43,8 +46,12 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class InsightsWebControllerTest {
@@ -168,6 +175,43 @@ class InsightsWebControllerTest {
         .andExpect(model().attribute("language", "pt"))
         .andExpect(model().attributeExists("metadata"))
         .andExpect(model().attribute("article", ARTICLE_PT));
+  }
+
+  @Test
+  void getInsightDetailPageMetadataHasJsonLd() throws Exception {
+    when(insightService.getArticleBySlug(eq(ARTICLE_EN.slug()), any())).thenReturn(ARTICLE_EN);
+
+    MvcResult result = mockMvc.perform(get("/en/insights/" + ARTICLE_EN.slug()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    PageMetadata metadata =
+        (PageMetadata) result.getModelAndView().getModel().get("metadata");
+    JsonNode jsonLd = JsonMapper.builder().build().readTree(metadata.getJsonLd());
+
+    assertEquals(ArticleDTOFixtures.STANDARD_TITLE, jsonLd.get("headline").asString());
+    assertEquals("http://localhost/en/insights/race-analysis-2024", jsonLd.get("url").asString());
+    assertEquals("2024-06-15", jsonLd.get("datePublished").asString());
+    assertEquals("http://localhost/img/endurancetrio-open-graph.png", jsonLd.get("image")
+        .asString());
+  }
+
+  @Test
+  void getInsightDetailPageMetadataOmitsDatePublishedWhenArticleHasNone() throws Exception {
+    ArticleDTO articleWithoutDate = ArticleDTOFixtures.withoutPublishedDate();
+    when(insightService.getArticleBySlug(eq(articleWithoutDate.slug()), any())).thenReturn(
+        articleWithoutDate
+    );
+
+    MvcResult result = mockMvc.perform(get("/en/insights/" + articleWithoutDate.slug()))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    PageMetadata metadata =
+        (PageMetadata) result.getModelAndView().getModel().get("metadata");
+    JsonNode jsonLd = JsonMapper.builder().build().readTree(metadata.getJsonLd());
+
+    assertFalse(jsonLd.has("datePublished"));
   }
 
   @Test

--- a/endurancetrio-business/src/test/java/com/endurancetrio/business/insight/fixtures/ArticleDTOFixture.java
+++ b/endurancetrio-business/src/test/java/com/endurancetrio/business/insight/fixtures/ArticleDTOFixture.java
@@ -27,6 +27,16 @@ import com.endurancetrio.business.insight.dto.ArticleDTO;
  */
 public class ArticleDTOFixture {
 
+  public static final String FEATURED_IMAGE = "/img/insights/insights-001.jpg";
+  public static final Integer FEATURED_IMAGE_WIDTH = 1200;
+  public static final Integer FEATURED_IMAGE_HEIGHT = 628;
+
+  public static final String META_TITLE = "Race Analysis 2024 - EnduranceTrio Insights";
+
+  public static final String SPECIAL_TITLE = "How a \"poor\" country shaped my journey";
+  public static final String SPECIAL_INTRO_TEXT = "<p>Intro with \"quotes\" & <b>html</b></p>";
+  public static final String SPECIAL_AUTHOR_NAME = "Author O'Brien";
+
   private ArticleDTOFixture() {
   }
 
@@ -53,6 +63,72 @@ public class ArticleDTOFixture {
     return new ArticleDTO(id, ArticleFixture.STANDARD_SLUG,
         ArticleContentFixture.STANDARD_TITLE, null, ArticleContentFixture.STANDARD_INTRO_TEXT, null,
         AuthorFixture.STANDARD_KNOWN_NAME, ArticleFixture.STANDARD_PUBLISHED_DATE, null, null, null,
+        null, null, ArticleContentFixture.STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} with a featured image and its dimensions.
+   *
+   * @return an ArticleDTO instance with a featured image
+   */
+  public static ArticleDTO withFeaturedImage() {
+    return new ArticleDTO(ArticleFixture.STANDARD_ID, ArticleFixture.STANDARD_SLUG,
+        ArticleContentFixture.STANDARD_TITLE, null, ArticleContentFixture.STANDARD_INTRO_TEXT, null,
+        AuthorFixture.STANDARD_KNOWN_NAME, ArticleFixture.STANDARD_PUBLISHED_DATE,
+        FEATURED_IMAGE, FEATURED_IMAGE_WIDTH, FEATURED_IMAGE_HEIGHT, null, null,
+        ArticleContentFixture.STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} without a published date.
+   *
+   * @return an ArticleDTO instance without a published date
+   */
+  public static ArticleDTO withoutPublishedDate() {
+    return new ArticleDTO(ArticleFixture.STANDARD_ID, ArticleFixture.STANDARD_SLUG,
+        ArticleContentFixture.STANDARD_TITLE, null, ArticleContentFixture.STANDARD_INTRO_TEXT, null,
+        AuthorFixture.STANDARD_KNOWN_NAME, null, null, null, null, null, null,
+        ArticleContentFixture.STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} with a meta title and a blank meta description.
+   *
+   * @return an ArticleDTO instance with a blank meta description
+   */
+  public static ArticleDTO withBlankMetaDescription() {
+    return new ArticleDTO(ArticleFixture.STANDARD_ID, ArticleFixture.STANDARD_SLUG,
+        ArticleContentFixture.STANDARD_TITLE, null, ArticleContentFixture.STANDARD_INTRO_TEXT, null,
+        AuthorFixture.STANDARD_KNOWN_NAME, ArticleFixture.STANDARD_PUBLISHED_DATE, null, null, null,
+        META_TITLE, "   ", ArticleContentFixture.STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} with a blank featured image.
+   *
+   * @return an ArticleDTO instance with a blank featured image
+   */
+  public static ArticleDTO withBlankFeaturedImage() {
+    return new ArticleDTO(ArticleFixture.STANDARD_ID, ArticleFixture.STANDARD_SLUG,
+        ArticleContentFixture.STANDARD_TITLE, null, ArticleContentFixture.STANDARD_INTRO_TEXT, null,
+        AuthorFixture.STANDARD_KNOWN_NAME, ArticleFixture.STANDARD_PUBLISHED_DATE, "", null, null,
+        null, null, ArticleContentFixture.STANDARD_LOCALE
+    );
+  }
+
+  /**
+   * Creates an {@link ArticleDTO} whose text fields contain double quotes, apostrophes and HTML.
+   *
+   * @return an ArticleDTO instance with special characters
+   */
+  public static ArticleDTO withSpecialCharacters() {
+    return new ArticleDTO(ArticleFixture.STANDARD_ID, ArticleFixture.STANDARD_SLUG,
+        SPECIAL_TITLE, null, SPECIAL_INTRO_TEXT, null,
+        SPECIAL_AUTHOR_NAME, ArticleFixture.STANDARD_PUBLISHED_DATE, null, null, null,
         null, null, ArticleContentFixture.STANDARD_LOCALE
     );
   }


### PR DESCRIPTION
## Description

Replaces the generic, static `<head>` metadata of public pages with dynamic, localized titles and descriptions built from real page data (athlete names, event titles, years, cities), refines the English and Portuguese SEO copy, and adds schema.org `Article` structured data to insight detail pages.

### Key changes

- **Dynamic page metadata** — athlete profile pages inject the athlete's known name; event overview, insights, and results pages include event title, year, and city; events-by-year pages include the competition year. Controllers resolve entities first and pass them as `MessageFormat` arguments to the metadata messages
- **Refined SEO copy** — English and Portuguese `messages*.properties` rewritten with keyword-rich per-page titles and descriptions (athletes directory, events directory, athlete profile, event overview/insights/results)
- **Article JSON-LD** — insight detail pages emit `schema.org/Article` structured data, serialized server-side by the new `JsonLdUtils` onto a new `PageMetadata.jsonLd` field and rendered via an empty-bodied `application/ld+json` script in the shared head fragment, keeping template sources free of language-injected JSON tokens and making escaping unit-testable
- **JSON-LD fallbacks** — `datePublished` omitted when unknown; description falls back from metaDescription to introText; images resolve against the base URL with the default Open Graph image as fallback
- **Testing** — new tests for `JsonLdUtils` serialization and updated controller tests, backed by shared article DTO fixtures
- **Documentation** — Javadoc on `PageMetadata` updated for the new field

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / code cleanup
- [ ] Build / tooling / CI
- [ ] Documentation
- [ ] Translation / language

## How Has This Been Tested?

Full Maven build (`./mvnw clean install`) — BUILD SUCCESS. Java 21 (Temurin), Linux.

## Checklist

- [x] My code follows the project's code style and conventions (see `docs/development.md#code--naming-conventions` and `AGENTS.md#key-conventions`)
- [x] The build runs successfully (`./mvnw clean install`)
- [x] I have updated the documentation (`AGENTS.md`, `README.md`, `docs/`, `DATABASE.md`, etc.) if needed
- [x] The commit messages follow the project's convention (50-char subject, 72-char body wrap)
